### PR TITLE
feat: simplify harbor() API by removing solver parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ When no agent or solver is specified, Inspect Harbor provides a default agent sc
 
 - **Agent Type**: [ReAct agent](https://inspect.aisi.org.uk/react-agent.html)
 - **Tools**: [`bash(timeout=300)`](https://inspect.aisi.org.uk/tools-standard.html#sec-bash-session), [`python(timeout=300)`](https://inspect.aisi.org.uk/tools-standard.html#sec-bash-and-python), [`memory()`](https://inspect.aisi.org.uk/tools-standard.html#sec-memory), [`update_plan()`](https://inspect.aisi.org.uk/tools-standard.html#sec-update-plan)
-- **Submission**: Disabled (`submit=False`) - agents write answers to files for evaluation
 - **Compaction**: [`CompactionEdit()`](https://inspect.aisi.org.uk/compaction.html) for context window management
 
 This default configuration is suitable for most Harbor tasks that require command execution and file manipulation.
@@ -309,7 +308,6 @@ The following parameters configure the Inspect Harbor task interface. They can b
 | `disable_verification` | Skip task verification checks | `true` or `false` |
 | `overwrite_cache` | Force re-download and overwrite cached tasks (default: `false`). Works for both git tasks and registry datasets. | `true` or `false` |
 | `sandbox_env_name` | Sandbox environment name (default: `"docker"`) | `"modal"` or `"docker"` |
-| `solver` | Custom solver (defaults to ReAct agent with bash/python/memory/update_plan tools) | `inspect_harbor/oracle` |
 
 **Note:** These are task-specific parameters passed with `-T`. For additional `inspect eval` command-line flags (like `--model`, `--message-limit`, `--epochs`, `--fail-on-error`, `--log-dir`, `--log-level`, `--max-tasks`, etc.), see the [Inspect eval CLI reference](https://inspect.aisi.org.uk/reference/inspect_eval.html) or [Python API reference](https://inspect.aisi.org.uk/reference/inspect_ai.html#eval).
 

--- a/src/inspect_harbor/harbor/_task.py
+++ b/src/inspect_harbor/harbor/_task.py
@@ -12,7 +12,6 @@ from harbor.tasks.client import TaskClient
 from inspect_ai import Task, task
 from inspect_ai.agent import react
 from inspect_ai.model import CompactionEdit
-from inspect_ai.solver import Solver
 from inspect_ai.tool import bash, memory, python, update_plan
 
 from inspect_harbor.harbor._converters import harbor_task_to_sample
@@ -33,7 +32,6 @@ def harbor(
     disable_verification: bool = False,
     overwrite_cache: bool = False,
     sandbox_env_name: str = "docker",
-    solver: Solver | None = None,
 ) -> Task:
     """Harbor task loader for Inspect AI.
 
@@ -51,7 +49,6 @@ def harbor(
         disable_verification: Disable task verification. Verfication checks whether task files exist.
         overwrite_cache: Force re-download and overwrite cached tasks (default: False).
         sandbox_env_name: Sandbox environment name (default: "docker").
-        solver: Optional custom solver. If None, uses react() with bash/python tools.
 
     Returns:
         Task: Configured Inspect AI task
@@ -78,11 +75,9 @@ def harbor(
 
     return Task(
         dataset=samples,
-        solver=solver
-        or react(
+        solver=react(
             tools=[bash(timeout=300), python(timeout=300), memory(), update_plan()],
             compaction=CompactionEdit(),
-            submit=False,  # Agent is expected to write a file with its answer
         ),
         scorer=harbor_scorer(),
         time_limit=max_timeout,


### PR DESCRIPTION
Simplifies the API by removing the solver parameter from harbor().

## Changes
- Remove solver parameter from harbor() function
- Remove submit=False from react solver
- Update README to clarify solver usage

Solvers should now be passed to `eval()` instead of `harbor()`.