### PR TITLE
fix: set a higher default memory limit for containers

### DIFF
--- a/src/inspect_harbor/harbor/_converters.py
+++ b/src/inspect_harbor/harbor/_converters.py
@@ -26,7 +26,10 @@ def harbor_to_compose_config(harbor_task: HarborTask) -> ComposeConfig:
 
     # Extract resource configuration from Harbor config
     cpus = float(env_config.cpus) if env_config.cpus is not None else 1.0
-    memory_mb = env_config.memory_mb if env_config.memory_mb is not None else 2048
+    # claude code is a nodejs app so requires ~ 2GB by itself so make room for it
+    MIN_MEMORY = 6144
+    memory_mb = env_config.memory_mb if env_config.memory_mb is not None else MIN_MEMORY
+    memory_mb = max(memory_mb, MIN_MEMORY)
     gpus = env_config.gpus if env_config.gpus is not None else 0
     gpu_types = env_config.gpu_types
     # Note: storage_mb is not currently supported by Inspect AI's ComposeService


### PR DESCRIPTION
we observed claude code running out of memory on memory-intensive samples (e.g ones involving qemu). this sets a minimum memory consumption budget of 6144 (not that does not consume physical memory, just sets an oom limit).