### PR TITLE
refactor: enforce 6GB minimum memory and remove time_limit

### DIFF
--- a/src/inspect_harbor/harbor/_converters.py
+++ b/src/inspect_harbor/harbor/_converters.py
@@ -45,19 +45,22 @@ def harbor_to_compose_config(
         if override_cpus is not None
         else (float(env_config.cpus) if env_config.cpus is not None else 1.0)
     )
+
+    # Harbor's default of 2048 MB (2 GB) is too restrictive for modern agents.
+    # Enforce a minimum of 6144 MB (6 GB) unless explicitly overridden.
+    MIN_MEMORY_MB = 6144  # 6 GB
     memory_mb = (
         override_memory_mb
         if override_memory_mb is not None
-        else env_config.memory_mb  # Could be None = unlimited
+        else max(env_config.memory_mb or 0, MIN_MEMORY_MB)
     )
+
     gpus = (
         override_gpus
         if override_gpus is not None
         else (env_config.gpus if env_config.gpus is not None else 0)
     )
     gpu_types = env_config.gpu_types
-    # Note: storage_mb is not supported - Docker Compose doesn't have standard storage
-
     gpu_deploy = _create_gpu_deploy_config(gpus, gpu_types)
 
     # Use existing docker-compose.yaml if present

--- a/src/inspect_harbor/harbor/_task.py
+++ b/src/inspect_harbor/harbor/_task.py
@@ -83,7 +83,6 @@ def harbor(
         )
         for ht in harbor_task_objects
     ]
-    max_timeout = _get_max_timeout_sec(harbor_task_objects)
 
     return Task(
         dataset=samples,
@@ -92,7 +91,6 @@ def harbor(
             compaction=CompactionEdit(),
         ),
         scorer=harbor_scorer(),
-        time_limit=max_timeout,
     )
 
 
@@ -266,9 +264,3 @@ def _load_from_registry(
     dataset_client = DatasetClient()
     downloaded_tasks = dataset_client.download_dataset_from_config(dataset_config)
     return [dt.local_path for dt in downloaded_tasks]
-
-
-def _get_max_timeout_sec(harbor_tasks: list[HarborTask]) -> int | None:
-    """Extract the maximum timeout_sec from a list of Harbor tasks."""
-    timeout_values = [ht.config.agent.timeout_sec for ht in harbor_tasks]
-    return int(max(timeout_values)) if timeout_values else None

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from harbor.models.task.task import Task as HarborTask
-from inspect_harbor.harbor._task import _get_max_timeout_sec, load_harbor_tasks
+from inspect_harbor.harbor._task import harbor, load_harbor_tasks
 
 
 def test_load_local_single_task():
@@ -284,36 +284,8 @@ def test_load_harbor_tasks_parameter_passing(
         mock_load_local.assert_called_once_with(*expected_call_args)
 
 
-@pytest.mark.parametrize(
-    "timeout_values,expected",
-    [
-        ([100, 200, 150], 200),  # Multiple timeouts, returns max
-        ([100.5], 100),  # Float conversion to int
-        ([], None),  # Empty list returns None
-    ],
-)
-def test_get_max_timeout_sec(
-    timeout_values: list[int | float], expected: int | None
-) -> None:
-    """Test _get_max_timeout_sec with various inputs."""
-    tasks = []
-    for val in timeout_values:
-        task = Mock(spec=HarborTask)
-        task.config = Mock()
-        task.config.agent = Mock()
-        task.config.agent.timeout_sec = val
-        tasks.append(task)
-
-    result = _get_max_timeout_sec(tasks)
-    assert result == expected
-    if expected is not None:
-        assert isinstance(result, int)
-
-
 def test_harbor_task_integration():
     """Integration test: Load a real Harbor task and verify Task object."""
-    from inspect_harbor.harbor._task import harbor
-
     # Load the test Harbor task fixture
     task_path = Path(__file__).parent / "fixtures" / "simple_task"
     assert task_path.exists(), f"Test fixture not found at {task_path}"
@@ -344,8 +316,6 @@ def test_harbor_task_integration():
 
 def test_harbor_task_with_overrides():
     """Integration test: Verify override parameters are applied to sample environment."""
-    from inspect_harbor.harbor._task import harbor
-
     # Load the test Harbor task fixture
     task_path = Path(__file__).parent / "fixtures" / "simple_task"
     assert task_path.exists(), f"Test fixture not found at {task_path}"


### PR DESCRIPTION
## Summary
- Enforces 6GB minimum memory for all tasks (respects higher values from task.toml or overrides)
- Removes `override_agent_timeout_sec` parameter (tasks no longer set `time_limit`)
- Improves README documentation with version resolution, n_tasks efficiency notes, and parameter combination clarifications

## Changes
### Memory Enforcement
- All tasks now use a minimum of 6GB memory
- Task config or override values ≥ 6GB are respected
- Values < 6GB are raised to 6GB minimum

### Agent Timeout Removal
- Removed `override_agent_timeout_sec` parameter from `harbor()` function
- Removed `time_limit` logic from Task creation
- Updated tests to remove timeout-related test cases

### Documentation Improvements
- Added version resolution explanation to `dataset_name_version` parameter (resolves to "head" > highest semver > lexically last)
- Added efficiency note to `n_tasks` parameter (downloads only n tasks vs entire dataset with `--max-samples`)
- Updated various README sections for improved clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)