### PR TITLE
fix: add RELEASE_PLEASE_TOKEN to update-registry workflow

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -50,6 +50,7 @@ jobs:
         if: steps.git-check.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           commit-message: 'chore: update Harbor registry tasks'
           title: 'Update Harbor Registry Tasks'
           body: |


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions permission error in the update-registry workflow by using `RELEASE_PLEASE_TOKEN` instead of the default `GITHUB_TOKEN`.

- Resolves the error: "GitHub Actions is not permitted to create or approve pull requests"
- Consistent with the approach used in `.github/workflows/release.yaml`