### PR TITLE
fix: enforce network mode & handle variable expansion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 # Note: harbor package requires Python >=3.12, so we cannot lower this requirement
 requires-python = ">=3.12"
 license = { text = "MIT License" }
-dependencies = ["inspect-ai>=0.3.176", "harbor>=0.1.44", "pyyaml"]
+dependencies = ["inspect-ai>=0.3.199", "harbor>=0.1.45", "pyyaml"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",

--- a/src/inspect_harbor/harbor/_converters.py
+++ b/src/inspect_harbor/harbor/_converters.py
@@ -71,12 +71,7 @@ def harbor_to_compose_config(
         with open(compose_yaml_path, encoding="utf-8") as f:
             raw_yaml = f.read()
 
-        # Expand ${VAR} references used by Harbor's Docker Compose files.
-        # Harbor's DinD mode passes these as env vars to `docker compose`;
-        # since we feed the YAML directly to sandbox providers, we must
-        # expand them ourselves.
         raw_yaml = _expand_compose_vars(raw_yaml, harbor_task, cpus, memory_mb)
-
         compose_dict = yaml.safe_load(raw_yaml)
         compose_config = ComposeConfig(**compose_dict)
 
@@ -202,23 +197,18 @@ def _expand_compose_vars(
     cpus: float,
     memory_mb: int,
 ) -> str:
-    """Expand ${VAR} references in a Harbor docker-compose.yaml string.
+    """Expand ${VAR} references in a Harbor docker-compose.yaml.
 
     Harbor passes these variables as environment variables to the
     ``docker compose`` process, which performs the substitution natively.
-    Since inspect_harbor is decoupled from the execution/provider layer
-    (it produces a ``ComposeConfig`` without invoking ``docker compose``),
-    we must perform the substitution here before YAML parsing.
 
-    The variable mapping matches Harbor's
-    ``_DaytonaDinD._compose_env_vars()`` logic:
+    The variable mapping matches:
     https://github.com/harbor-framework/harbor/blob/c935c6c06471e6cd891cda50f9e1b65e35bbd486/src/harbor/environments/daytona.py#L329
 
     Limitation: ``HOST_*`` paths (the host side of volume mounts) are set to
     the same container-side ``EnvironmentPaths`` values as ``ENV_*``. In
-    Harbor's DinD setup these differ (e.g. ``/harbor/logs/verifier`` on the
-    VM vs ``/logs/verifier`` in the container), but we cannot resolve
-    host-side paths here because they depend on the sandbox provider.
+    Harbor's DinD setup these differ, but we cannot resolve host-side paths
+    here because they depend on the sandbox provider.
     """
     if "${" not in raw_yaml:
         return raw_yaml

--- a/src/inspect_harbor/harbor/_converters.py
+++ b/src/inspect_harbor/harbor/_converters.py
@@ -1,7 +1,10 @@
 """Converters for Harbor tasks to Inspect AI structures."""
 
+import re
+
 import yaml
 from harbor.models.task.task import Task as HarborTask
+from harbor.models.trial.paths import EnvironmentPaths
 from inspect_ai.dataset import Sample
 from inspect_ai.util import (
     ComposeBuild,
@@ -66,8 +69,15 @@ def harbor_to_compose_config(
     # Use existing docker-compose.yaml if present
     if compose_yaml_path.exists():
         with open(compose_yaml_path, encoding="utf-8") as f:
-            compose_dict = yaml.safe_load(f)
+            raw_yaml = f.read()
 
+        # Expand ${VAR} references used by Harbor's Docker Compose files.
+        # Harbor's DinD mode passes these as env vars to `docker compose`;
+        # since we feed the YAML directly to sandbox providers, we must
+        # expand them ourselves.
+        raw_yaml = _expand_compose_vars(raw_yaml, harbor_task, cpus, memory_mb)
+
+        compose_dict = yaml.safe_load(raw_yaml)
         compose_config = ComposeConfig(**compose_dict)
 
         # Apply resource limits and network mode from Harbor config to services
@@ -184,3 +194,60 @@ def _create_gpu_deploy_config(
             reservations=ComposeResourceReservations(devices=[device_reservation])
         )
     )
+
+
+def _expand_compose_vars(
+    raw_yaml: str,
+    harbor_task: HarborTask,
+    cpus: float,
+    memory_mb: int,
+) -> str:
+    """Expand ${VAR} references in a Harbor docker-compose.yaml string.
+
+    Harbor passes these variables as environment variables to the
+    ``docker compose`` process, which performs the substitution natively.
+    Since inspect_harbor is decoupled from the execution/provider layer
+    (it produces a ``ComposeConfig`` without invoking ``docker compose``),
+    we must perform the substitution here before YAML parsing.
+
+    The variable mapping matches Harbor's
+    ``_DaytonaDinD._compose_env_vars()`` logic:
+    https://github.com/harbor-framework/harbor/blob/c935c6c06471e6cd891cda50f9e1b65e35bbd486/src/harbor/environments/daytona.py#L329
+
+    Limitation: ``HOST_*`` paths (the host side of volume mounts) are set to
+    the same container-side ``EnvironmentPaths`` values as ``ENV_*``. In
+    Harbor's DinD setup these differ (e.g. ``/harbor/logs/verifier`` on the
+    VM vs ``/logs/verifier`` in the container), but we cannot resolve
+    host-side paths here because they depend on the sandbox provider.
+    """
+    if "${" not in raw_yaml:
+        return raw_yaml
+
+    env_dir = str(harbor_task.paths.environment_dir)
+    task_name = harbor_task.name
+
+    var_map: dict[str, str] = {
+        "CONTEXT_DIR": env_dir,
+        "MAIN_IMAGE_NAME": f"hb__{task_name}",
+        "CPUS": str(int(cpus)),
+        "MEMORY": f"{memory_mb}M",
+        "HOST_VERIFIER_LOGS_PATH": str(EnvironmentPaths.verifier_dir),
+        "HOST_AGENT_LOGS_PATH": str(EnvironmentPaths.agent_dir),
+        "HOST_ARTIFACTS_PATH": str(EnvironmentPaths.artifacts_dir),
+        "ENV_VERIFIER_LOGS_PATH": str(EnvironmentPaths.verifier_dir),
+        "ENV_AGENT_LOGS_PATH": str(EnvironmentPaths.agent_dir),
+        "ENV_ARTIFACTS_PATH": str(EnvironmentPaths.artifacts_dir),
+    }
+
+    # Also pull TEST_DIR from the task's env if set
+    task_env = harbor_task.config.verifier.env or {}
+    if "TEST_DIR" in task_env:
+        var_map["TEST_DIR"] = task_env["TEST_DIR"]
+    else:
+        var_map["TEST_DIR"] = str(EnvironmentPaths.tests_dir)
+
+    def _replace(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        return var_map.get(var_name, match.group(0))
+
+    return re.sub(r"\$\{([^}]+)}", _replace, raw_yaml)

--- a/src/inspect_harbor/harbor/_converters.py
+++ b/src/inspect_harbor/harbor/_converters.py
@@ -229,7 +229,6 @@ def _expand_compose_vars(
         "ENV_ARTIFACTS_PATH": str(EnvironmentPaths.artifacts_dir),
     }
 
-    # Also pull TEST_DIR from the task's env if set
     task_env = harbor_task.config.verifier.env or {}
     if "TEST_DIR" in task_env:
         var_map["TEST_DIR"] = task_env["TEST_DIR"]

--- a/src/inspect_harbor/harbor/_converters.py
+++ b/src/inspect_harbor/harbor/_converters.py
@@ -70,11 +70,15 @@ def harbor_to_compose_config(
 
         compose_config = ComposeConfig(**compose_dict)
 
-        # Apply resource limits from Harbor config to services
+        # Apply resource limits and network mode from Harbor config to services
         if compose_config.services:
             for service in compose_config.services.values():
                 service.cpus = cpus
                 service.mem_limit = f"{memory_mb}m" if memory_mb is not None else None
+                # Harbor's behavior: allow_internet=False forces network
+                # isolation; otherwise don't touch network_mode.
+                if not env_config.allow_internet:
+                    service.network_mode = "none"
                 if gpu_deploy:
                     service.deploy = gpu_deploy
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -28,6 +28,7 @@ def test_harbor_to_compose_config_with_existing_compose_yaml():
     mock_env_config.memory_mb = 4096
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.allow_internet = True
     mock_task.config.environment = mock_env_config
 
     # Mock docker-compose.yaml content (without version field as ComposeConfig doesn't accept it)
@@ -56,6 +57,8 @@ services:
         assert service.cpus == 2.0
         # 6GB minimum is applied (config has 4096m which is below minimum)
         assert service.mem_limit == "6144m"
+        # No network_mode in compose file + allow_internet=True -> left unset
+        assert service.network_mode is None
 
 
 def test_harbor_to_compose_config_with_dockerfile():
@@ -181,6 +184,111 @@ def test_harbor_to_compose_config_default_resource_limits():
         assert service.cpus == 1.0
         # When memory_mb is None, 6GB minimum is applied
         assert service.mem_limit == "6144m"
+
+
+def test_harbor_to_compose_config_compose_yaml_no_internet_overrides_network_mode():
+    """Test that allow_internet=False forces network_mode=none even when compose file sets it."""
+    mock_task = Mock()
+    mock_paths = Mock()
+    mock_paths.environment_dir = Path("/task/environment")
+    mock_task.paths = mock_paths
+
+    mock_env_config = Mock()
+    mock_env_config.cpus = 1.0
+    mock_env_config.memory_mb = 2048
+    mock_env_config.gpus = 0
+    mock_env_config.gpu_types = None
+    mock_env_config.allow_internet = False
+    mock_task.config.environment = mock_env_config
+
+    compose_yaml_content = """
+services:
+  default:
+    image: python:3.11
+    network_mode: bridge
+"""
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=compose_yaml_content)),
+    ):
+        mock_exists.side_effect = lambda: True
+
+        result = harbor_to_compose_config(mock_task)
+
+        service = result.services["default"]
+        assert service.network_mode == "none"
+
+
+def test_harbor_to_compose_config_compose_yaml_preserves_custom_network_mode():
+    """Test that compose file's network_mode is preserved when allow_internet=True."""
+    mock_task = Mock()
+    mock_paths = Mock()
+    mock_paths.environment_dir = Path("/task/environment")
+    mock_task.paths = mock_paths
+
+    mock_env_config = Mock()
+    mock_env_config.cpus = 1.0
+    mock_env_config.memory_mb = 2048
+    mock_env_config.gpus = 0
+    mock_env_config.gpu_types = None
+    mock_env_config.allow_internet = True
+    mock_task.config.environment = mock_env_config
+
+    compose_yaml_content = """
+services:
+  default:
+    image: python:3.11
+    network_mode: host
+"""
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=compose_yaml_content)),
+    ):
+        mock_exists.side_effect = lambda: True
+
+        result = harbor_to_compose_config(mock_task)
+
+        service = result.services["default"]
+        assert service.network_mode == "host"
+
+
+def test_harbor_to_compose_config_compose_yaml_no_network_mode_left_unset():
+    """Test that compose file without network_mode is left unset when allow_internet=True.
+
+    This preserves Docker Compose's default project network with inter-service DNS,
+    matching Harbor's behavior of not touching network_mode when allow_internet=True.
+    """
+    mock_task = Mock()
+    mock_paths = Mock()
+    mock_paths.environment_dir = Path("/task/environment")
+    mock_task.paths = mock_paths
+
+    mock_env_config = Mock()
+    mock_env_config.cpus = 1.0
+    mock_env_config.memory_mb = 2048
+    mock_env_config.gpus = 0
+    mock_env_config.gpu_types = None
+    mock_env_config.allow_internet = True
+    mock_task.config.environment = mock_env_config
+
+    compose_yaml_content = """
+services:
+  default:
+    image: python:3.11
+"""
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=compose_yaml_content)),
+    ):
+        mock_exists.side_effect = lambda: True
+
+        result = harbor_to_compose_config(mock_task)
+
+        service = result.services["default"]
+        assert service.network_mode is None
 
 
 def test_harbor_to_compose_config_network_mode_with_internet():

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -10,6 +10,7 @@ from inspect_ai.dataset import Sample
 from inspect_ai.util import ComposeBuild, ComposeConfig, SandboxEnvironmentSpec
 from inspect_ai.util._sandbox.compose import ComposeDeviceReservation
 from inspect_harbor.harbor._converters import (
+    _expand_compose_vars,
     harbor_task_to_sample,
     harbor_to_compose_config,
 )
@@ -760,6 +761,112 @@ def test_harbor_task_to_sample_passes_overrides(mock_harbor_task: Any):
         assert service.deploy.resources.reservations.devices is not None
         device = service.deploy.resources.reservations.devices[0]
         assert device.count == 4
+
+
+def test_expand_compose_vars_basic():
+    """Test that ${VAR} references are expanded in compose YAML."""
+    mock_task = Mock()
+    mock_task.name = "my-task"
+    mock_task.paths = Mock()
+    mock_task.paths.environment_dir = Path("/cache/tasks/abc/my-task/environment")
+    mock_task.config.verifier.env = {}
+
+    raw = """\
+services:
+  main:
+    build:
+      context: ${CONTEXT_DIR}
+      dockerfile: Dockerfile
+    image: ${MAIN_IMAGE_NAME}
+    deploy:
+      resources:
+        limits:
+          cpus: ${CPUS}
+          memory: ${MEMORY}
+"""
+    result = _expand_compose_vars(raw, mock_task, cpus=4.0, memory_mb=8192)
+
+    assert "${" not in result
+    assert "/cache/tasks/abc/my-task/environment" in result
+    assert "hb__my-task" in result
+    assert "cpus: 4" in result
+    assert "memory: 8192M" in result
+
+
+def test_expand_compose_vars_no_vars():
+    """Test that YAML without variables is returned unchanged."""
+    mock_task = Mock()
+    mock_task.name = "t"
+    mock_task.paths = Mock()
+    mock_task.paths.environment_dir = Path("/env")
+    mock_task.config.verifier.env = {}
+
+    raw = "services:\n  default:\n    image: python:3.12\n"
+    assert _expand_compose_vars(raw, mock_task, 1.0, 2048) == raw
+
+
+def test_expand_compose_vars_unknown_left_as_is():
+    """Test that unknown variables are left as literal strings."""
+    mock_task = Mock()
+    mock_task.name = "t"
+    mock_task.paths = Mock()
+    mock_task.paths.environment_dir = Path("/env")
+    mock_task.config.verifier.env = {}
+
+    raw = "image: ${UNKNOWN_VAR}"
+    result = _expand_compose_vars(raw, mock_task, 1.0, 2048)
+    assert result == "image: ${UNKNOWN_VAR}"
+
+
+def test_expand_compose_vars_test_dir_from_verifier_env():
+    """Test that TEST_DIR is pulled from verifier env if set."""
+    mock_task = Mock()
+    mock_task.name = "t"
+    mock_task.paths = Mock()
+    mock_task.paths.environment_dir = Path("/env")
+    mock_task.config.verifier.env = {"TEST_DIR": "/custom/tests"}
+
+    raw = "TEST_DIR=${TEST_DIR}"
+    result = _expand_compose_vars(raw, mock_task, 1.0, 2048)
+    assert result == "TEST_DIR=/custom/tests"
+
+
+def test_expand_compose_vars_in_harbor_to_compose_config(tmp_path: Path):
+    """Test end-to-end: compose YAML with variables is expanded before parsing."""
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+
+    compose_yaml = env_dir / "docker-compose.yaml"
+    compose_yaml.write_text("""\
+services:
+  default:
+    build:
+      context: ${CONTEXT_DIR}
+      dockerfile: Dockerfile
+    image: ${MAIN_IMAGE_NAME}
+""")
+
+    # Create a Dockerfile so the build context is valid
+    (env_dir / "Dockerfile").write_text("FROM python:3.12\n")
+
+    mock_task = Mock()
+    mock_task.name = "test-task"
+    mock_task.paths = Mock()
+    mock_task.paths.environment_dir = env_dir
+    mock_task.config.environment = Mock()
+    mock_task.config.environment.cpus = 2
+    mock_task.config.environment.memory_mb = 8192
+    mock_task.config.environment.gpus = 0
+    mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.allow_internet = True
+    mock_task.config.verifier.env = {}
+
+    result = harbor_to_compose_config(mock_task)
+
+    service = result.services["default"]
+    assert service.image == "hb__test-task"
+    assert isinstance(service.build, ComposeBuild)
+    assert service.build.context == str(env_dir)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -932,15 +932,6 @@ wheels = [
 ]
 
 [[package]]
-name = "frozendict"
-version = "2.4.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
-]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1080,7 +1071,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.1.44"
+version = "0.1.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "claude-agent-sdk" },
@@ -1108,9 +1099,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/e4/32cf69b2ec781a9d1f009ce5213660a654eebfd8bc494270efd2c15e8c88/harbor-0.1.44.tar.gz", hash = "sha256:4f375d8edcf3e59494b60d8a842842735312bdc0f128d7d535d5f123fd20560b", size = 619481, upload-time = "2026-02-09T05:31:12.371Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/78/e4da8b6c33b8c7a5d5d923cc296628d309bdf642f9ba66ed0d5b3301efc4/harbor-0.1.45.tar.gz", hash = "sha256:f8999cdb21978e33478d460ed6253c52b729b6d04d76ce119a5ef23d3bf6c306", size = 650970, upload-time = "2026-02-27T01:21:35.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/d8/0e0a26fb3c8a07e4e9806085e2a95070cb4c73f6bd862a16f7da4d813299/harbor-0.1.44-py3-none-any.whl", hash = "sha256:445c34efadef242bcd9908781af13632798d81be8021f13f030239920bbda782", size = 704529, upload-time = "2026-02-09T05:31:10.945Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/003653587735fea639fbb6b2221cda8dbe03cc9c1af9d292f055d5a6da42/harbor-0.1.45-py3-none-any.whl", hash = "sha256:ea1494f2dc1cf4286c7d390b3d8e89bb23c201ab9c570117c8319fb57a39d56a", size = 741599, upload-time = "2026-02-27T01:21:33.492Z" },
 ]
 
 [[package]]
@@ -1327,7 +1318,7 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.176"
+version = "0.3.199"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioboto3" },
@@ -1338,7 +1329,6 @@ dependencies = [
     { name = "click" },
     { name = "debugpy" },
     { name = "docstring-parser" },
-    { name = "frozendict" },
     { name = "fsspec" },
     { name = "httpx" },
     { name = "ijson" },
@@ -1365,12 +1355,13 @@ dependencies = [
     { name = "tiktoken" },
     { name = "typing-extensions" },
     { name = "universal-pathlib" },
+    { name = "zipfile-zstd", marker = "python_full_version < '3.14'" },
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/c3/4c12f9c8082dbeaa50f185c868a9ef928a931aaaf0f578e2ad03bd4c9640/inspect_ai-0.3.176.tar.gz", hash = "sha256:7effe9ca4838cedb1d1baae85f60b9e36a131c4f7ceec36009c1ed805ae52b0d", size = 43417804, upload-time = "2026-02-10T22:11:39.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/af/d7f0d100016e8fb598fdc35b3dffbbd84b1a03a05b193dd0ade26d6f9510/inspect_ai-0.3.199.tar.gz", hash = "sha256:851c937315966ab6324d6dd00799656117e116941bd682e403a95a951b0d1909", size = 45332746, upload-time = "2026-03-17T19:14:08.423Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/5a/750fe738ec45a8f3baed17ea93a6bb797608e1b86d9cbadff9c8b81fc11a/inspect_ai-0.3.176-py3-none-any.whl", hash = "sha256:4ead9bd2b9dc7a55557da43e084f73598f78d8fa2cb46f6ef4dbe5f4e4b8bb72", size = 34578242, upload-time = "2026-02-10T22:11:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5c/138ed2c5eeb43cb6dab4035cd0570227b61565de973676877f0bb24d2752/inspect_ai-0.3.199-py3-none-any.whl", hash = "sha256:61175f72cee65705ef551417c8806649a85f9886f4cb0276feb3fdd433a8cbc4", size = 36339250, upload-time = "2026-03-17T19:14:04.634Z" },
 ]
 
 [[package]]
@@ -1395,8 +1386,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "harbor", specifier = ">=0.1.44" },
-    { name = "inspect-ai", specifier = ">=0.3.176" },
+    { name = "harbor", specifier = ">=0.1.45" },
+    { name = "inspect-ai", specifier = ">=0.3.199" },
     { name = "pyyaml" },
 ]
 
@@ -1526,14 +1517,11 @@ wheels = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ply" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844, upload-time = "2026-02-28T00:53:19.637Z" },
 ]
 
 [[package]]
@@ -2003,11 +1991,11 @@ wheels = [
 
 [[package]]
 name = "nest-asyncio2"
-version = "1.7.1"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/eb/ecf8bbf9d22a4e8f7be1628336fe0202da7660790053aa28abeb6c15eb14/nest_asyncio2-1.7.1.tar.gz", hash = "sha256:a1fe5bbbd20894dcceb1842322d74992c5834d5ab692af2c4f59a9a4fcf75fe8", size = 13797, upload-time = "2025-11-20T20:46:07.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/48/c1f1ddcfd04bba60470235c2f83733ecff43ebe068dc7715aab60bc92ad8/nest_asyncio2-1.7.1-py3-none-any.whl", hash = "sha256:f83bc1744c3cfa7d47fd29431e5e168db6cb76eda1bb20108955c32f60d7eddf", size = 7504, upload-time = "2025-11-20T20:46:05.704Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
 ]
 
 [[package]]
@@ -2252,15 +2240,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]
@@ -3951,6 +3930,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zipfile-zstd"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/3a/bc3011d26bbb490741f58c28a2df559445c59e8524cbbb71ecf33db23bb7/zipfile_zstd-0.0.4-py3-none-any.whl", hash = "sha256:c8e07be35765c072eb7b1be715c89ecb248a1127b014e12a9b8ac7db2600c166", size = 4058, upload-time = "2021-12-08T07:38:14.715Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Enforce `allow_internet` network mode in the compose-file path (previously only applied in the programmatic path)
- Use `EnvironmentPaths` from harbor in `_expand_compose_vars` to handle variables in compose files