### PR TITLE
fix: apply resource overrides only to default service

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Task functions (like `terminal_bench()`, `swe_lancer_diamond()`, etc.) accept th
 | `override_memory_mb` | Override the memory (in MB) from `task.toml` | `None` | `16384` | `16384` |
 | `override_gpus` | Override the number of GPUs from `task.toml` | `None` | `1` | `1` |
 
+> **Multi-service compose & DinD providers:** Resource overrides are applied only to the **default service** (selected by `x-default: true`, or a service named "default"/"main", or the first service). Sidecar services run without explicit resource limits, within the sandbox's total capacity. For DinD-based sandbox providers (e.g. Daytona) that aggregate per-service resources to size the VM, you can control sandbox-level resources directly via the provider's compose extension (e.g. `x-daytona: { resources: { cpu: 4, memory: 8 } }`) in your `docker-compose.yaml`. See the [Daytona sandbox provider docs](https://github.com/meridianlabs-ai/inspect_sandboxes) for details.
+
 ### Example
 
 Here's an example showing how to use multiple parameters together:

--- a/src/inspect_harbor/harbor/_converters.py
+++ b/src/inspect_harbor/harbor/_converters.py
@@ -30,9 +30,9 @@ def harbor_to_compose_config(
 
     Args:
         harbor_task: The Harbor task to convert.
-        override_cpus: Override the number of CPUs for the environment.
-        override_memory_mb: Override the memory (in MB) for the environment.
-        override_gpus: Override the number of GPUs for the environment.
+        override_cpus: Override the number of CPUs for the default service.
+        override_memory_mb: Override the memory (in MB) for the default service.
+        override_gpus: Override the number of GPUs for the default service.
 
     Returns:
         ComposeConfig: The compose configuration for the task.
@@ -75,17 +75,19 @@ def harbor_to_compose_config(
         compose_dict = yaml.safe_load(raw_yaml)
         compose_config = ComposeConfig(**compose_dict)
 
-        # Apply resource limits and network mode from Harbor config to services
         if compose_config.services:
-            for service in compose_config.services.values():
-                service.cpus = cpus
-                service.mem_limit = f"{memory_mb}m" if memory_mb is not None else None
-                # Harbor's behavior: allow_internet=False forces network
-                # isolation; otherwise don't touch network_mode.
-                if not env_config.allow_internet:
+            _, default_service = _find_default_service(compose_config)
+            default_service.cpus = cpus
+            default_service.mem_limit = (
+                f"{memory_mb}m" if memory_mb is not None else None
+            )
+            if gpu_deploy:
+                default_service.deploy = gpu_deploy
+
+            # Network isolation applies to all services.
+            if not env_config.allow_internet:
+                for service in compose_config.services.values():
                     service.network_mode = "none"
-                if gpu_deploy:
-                    service.deploy = gpu_deploy
 
         return compose_config
     else:
@@ -155,6 +157,21 @@ def harbor_task_to_sample(
             "harbor_config": harbor_task.config.model_dump(),
         },
     )
+
+
+def _find_default_service(config: ComposeConfig) -> tuple[str, ComposeService]:
+    """Find the default service in a compose config.
+
+    Priority: ``x-default: true`` > service named "default" or "main" > first.
+    """
+    for name, svc in config.services.items():
+        if svc.x_default:
+            return name, svc
+    for candidate in ("default", "main"):
+        if candidate in config.services:
+            return candidate, config.services[candidate]
+    name = next(iter(config.services))
+    return name, config.services[name]
 
 
 def _create_gpu_deploy_config(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -763,6 +763,157 @@ def test_harbor_task_to_sample_passes_overrides(mock_harbor_task: Any):
         assert device.count == 4
 
 
+MULTI_SERVICE_YAML = """\
+services:
+  main:
+    image: python:3.11
+    command: tail -f /dev/null
+  helper:
+    image: redis:7
+"""
+
+
+def _make_multi_service_task(
+    cpus: float = 4,
+    memory_mb: int = 8192,
+    gpus: int = 0,
+    gpu_types: list[str] | None = None,
+    allow_internet: bool = True,
+) -> Mock:
+    mock_task = Mock()
+    mock_task.name = "multi-svc-task"
+    mock_task.paths = Mock()
+    mock_task.paths.environment_dir = Path("/task/environment")
+    mock_task.config.environment = Mock()
+    mock_task.config.environment.cpus = cpus
+    mock_task.config.environment.memory_mb = memory_mb
+    mock_task.config.environment.gpus = gpus
+    mock_task.config.environment.gpu_types = gpu_types
+    mock_task.config.environment.allow_internet = allow_internet
+    mock_task.config.verifier.env = {}
+    return mock_task
+
+
+def test_multi_service_resources_only_on_default_service():
+    """Only the default ('main') service gets resource limits."""
+    mock_task = _make_multi_service_task(cpus=4, memory_mb=8192)
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=MULTI_SERVICE_YAML)),
+    ):
+        mock_exists.side_effect = lambda: True
+        result = harbor_to_compose_config(mock_task)
+
+    # Default service ("main") gets resources
+    assert result.services["main"].cpus == 4
+    assert result.services["main"].mem_limit == "8192m"
+
+    # Sidecar ("helper") is untouched
+    assert result.services["helper"].cpus is None
+    assert result.services["helper"].mem_limit is None
+
+
+def test_multi_service_overrides_only_on_default_service():
+    """Overrides are applied only to the default service."""
+    mock_task = _make_multi_service_task()
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=MULTI_SERVICE_YAML)),
+    ):
+        mock_exists.side_effect = lambda: True
+        result = harbor_to_compose_config(
+            mock_task, override_cpus=2, override_memory_mb=4096
+        )
+
+    assert result.services["main"].cpus == 2
+    assert result.services["main"].mem_limit == "4096m"
+    assert result.services["helper"].cpus is None
+    assert result.services["helper"].mem_limit is None
+
+
+def test_multi_service_gpu_only_on_default_service():
+    """GPU deploy config is applied only to the default service."""
+    mock_task = _make_multi_service_task(gpus=1, gpu_types=["H100"])
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=MULTI_SERVICE_YAML)),
+    ):
+        mock_exists.side_effect = lambda: True
+        result = harbor_to_compose_config(mock_task)
+
+    assert result.services["main"].deploy is not None
+    assert result.services["helper"].deploy is None
+
+
+def test_multi_service_network_isolation_all_services():
+    """Network isolation applies to all services, not just default."""
+    mock_task = _make_multi_service_task(allow_internet=False)
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=MULTI_SERVICE_YAML)),
+    ):
+        mock_exists.side_effect = lambda: True
+        result = harbor_to_compose_config(mock_task)
+
+    assert result.services["main"].network_mode == "none"
+    assert result.services["helper"].network_mode == "none"
+
+
+def test_multi_service_x_default_takes_priority():
+    """A service with x-default: true is chosen over name-based matching."""
+    yaml_with_x_default = """\
+services:
+  main:
+    image: python:3.11
+  sidecar:
+    image: redis:7
+    x-default: true
+"""
+    mock_task = _make_multi_service_task(cpus=8, memory_mb=16384)
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=yaml_with_x_default)),
+    ):
+        mock_exists.side_effect = lambda: True
+        result = harbor_to_compose_config(mock_task)
+
+    # x-default service gets resources, not "main"
+    assert result.services["sidecar"].cpus == 8
+    assert result.services["sidecar"].mem_limit == "16384m"
+    assert result.services["main"].cpus is None
+    assert result.services["main"].mem_limit is None
+
+
+def test_multi_service_first_service_fallback():
+    """When no service is named 'default'/'main' or has x-default, first wins."""
+    yaml_no_default = """\
+services:
+  app:
+    image: python:3.11
+  db:
+    image: postgres:16
+"""
+    mock_task = _make_multi_service_task(cpus=2, memory_mb=8192)
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=yaml_no_default)),
+    ):
+        mock_exists.side_effect = lambda: True
+        result = harbor_to_compose_config(mock_task)
+
+    # First service gets resources
+    assert result.services["app"].cpus == 2
+    assert result.services["app"].mem_limit == "8192m"
+    assert result.services["db"].cpus is None
+    assert result.services["db"].mem_limit is None
+
+
 def test_expand_compose_vars_basic():
     """Test that ${VAR} references are expanded in compose YAML."""
     mock_task = Mock()


### PR DESCRIPTION
- Apply resource overrides (CPU, memory, GPU) only to the **default service** in multi-service compose configs, matching Harbor's behavior where sidecars run without explicit limits
- Default service selection: `x-default: true` > name "default"/"main" > first service
- Network isolation (`allow_internet=False`) still applies to all services
- Documents DinD provider resource aggregation behavior and `x-daytona.resources` workaround in README and docstrings

Closes #55