### PR TITLE
chore: bump workflow actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,13 +20,13 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install dependencies
         run: uv sync
       - name: Lint with Ruff
@@ -40,13 +40,13 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install dependencies
         run: uv sync
       - name: Type check with pyright
@@ -58,15 +58,15 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install dependencies
         run: uv sync
       - name: Run tests with coverage
@@ -84,13 +84,13 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Install build dependencies
         run: uv pip install --system build
       - name: Build package

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,11 +18,11 @@ jobs:
       name: pypi
       url: https://pypi.org/p/inspect-harbor
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Display version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,11 +32,11 @@ jobs:
       name: pypi
       url: https://pypi.org/p/inspect-harbor
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Display version

--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
- Silences the Node.js 20 deprecation warning surfaced during the recent `update-registry.yml` manual trigger. GitHub will flip the default to Node 24 on Jun 2, 2026 and remove Node 20 on Sep 16, 2026.
- Bumps only the three actions GitHub flagged as Node 20-backed; the remaining pins (create-pull-request, release-please, coverage-comment, pypi-publish) already support Node 24.