### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/gen-stderr.txt
+++ b/gen-stderr.txt
@@ -1,0 +1,25 @@
+
+⚠ 23 dataset(s) could not be resolved to an org on https://registry.harborframework.com and fell back to the search URL:
+  - bfcl_parity@1.0
+  - bird-bench@parity
+  - code-contests@1.0
+  - cooperbench@1.0
+  - gso@1.0
+  - kumo@1.0
+  - kumo@easy
+  - kumo@hard
+  - kumo@parity
+  - ml-dev-bench@1.0
+  - pixiu@parity
+  - researchcodebench@1.0
+  - spider2-dbt@1.0
+  - spreadsheetbench-verified@1.0
+  - swe-lancer-diamond@all
+  - swe-lancer-diamond@ic
+  - swe-lancer-diamond@manager
+  - swebench-verified@1.0
+  - swebench_multilingual@1.0
+  - swesmith@1.0
+  - swtbench-verified@1.0
+  - terminal-bench@2.0
+  - terminal-bench-sample@2.0

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3236,7 +3236,7 @@ def rexbench_1_0(
 
     Dataset: rexbench@1.0
     Version: 1.0
-    Harbor URL: https://registry.harborframework.com/datasets?q=rexbench
+    Harbor URL: https://registry.harborframework.com/datasets/rexbench/rexbench/latest
     """
     return _harbor_base(
         dataset_name_version="rexbench@1.0",
@@ -3266,7 +3266,7 @@ def rexbench(
 
     Dataset: rexbench
     Version: Latest available (1.0 when generated)
-    Harbor URL: https://registry.harborframework.com/datasets?q=rexbench
+    Harbor URL: https://registry.harborframework.com/datasets/rexbench/rexbench/latest
     """
     return _harbor_base(
         dataset_name_version="rexbench",


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
(none — all datasets already had overrides)
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks