### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -33,15 +33,17 @@ jobs:
       - name: Generate tasks
         id: generate
         run: |
-          uv run python scripts/generate_tasks.py 2> gen-stderr.txt
-          cat gen-stderr.txt >&2
+          # Write workflow-only artifacts under $RUNNER_TEMP so they never
+          # enter the working tree and get committed by create-pull-request.
+          uv run python scripts/generate_tasks.py 2> "$RUNNER_TEMP/gen-stderr.txt"
+          cat "$RUNNER_TEMP/gen-stderr.txt" >&2
           # Extract auto-stubbed dataset names (if any) for the PR body.
           # The generator logs them one-per-line as "  - name" between the
           # "auto-stubbed:" header and the "Fill in" footer.
-          awk '/auto-stubbed:$/{flag=1; next} /^  Fill in/{flag=0} flag && /^  - /{sub(/^  - /,""); print}' gen-stderr.txt > stubbed.txt || true
+          awk '/auto-stubbed:$/{flag=1; next} /^  Fill in/{flag=0} flag && /^  - /{sub(/^  - /,""); print}' "$RUNNER_TEMP/gen-stderr.txt" > "$RUNNER_TEMP/stubbed.txt" || true
           {
             echo "stubbed<<EOF"
-            cat stubbed.txt
+            cat "$RUNNER_TEMP/stubbed.txt"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -634,7 +634,10 @@ scale-ai/swe-atlas-qna:
   title: SWE-Atlas (QnA)
 
 scale-ai/swe-atlas-rf:
-  categories: []
+  categories:
+  - Coding
+  repo: https://github.com/scaleapi/SWE-Atlas
+  title: SWE-Atlas (Refactoring)
 
 scale-ai/swe-atlas-tw:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -633,6 +633,9 @@ scale-ai/swe-atlas-qna:
   repo: https://github.com/scaleapi/SWE-Atlas
   title: SWE-Atlas (QnA)
 
+scale-ai/swe-atlas-rf:
+  categories: []
+
 scale-ai/swe-atlas-tw:
   categories:
   - Coding

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -665,6 +665,8 @@
   task_function: scale_ai_swe_atlas_rf
   samples: 70
   version: latest
+  categories:
+  - Coding
 - title: scale-ai/swe-atlas-tw
   path: registry/scale_ai_swe_atlas_tw.html
   desc: SWE-Atlas - Test Writing -- A benchmark of comprehensive test writing problems for coding agents. Checkout for instructions on running it.

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -658,6 +658,13 @@
   version: latest
   categories:
   - Coding
+- title: scale-ai/swe-atlas-rf
+  path: registry/scale_ai_swe_atlas_rf.html
+  desc: SWE-Atlas - Refactoring -- A benchmark of refactoring tasks for coding agents.
+  desc_trunc: SWE-Atlas - Refactoring -- A benchmark of refactoring tasks for coding agents.
+  task_function: scale_ai_swe_atlas_rf
+  samples: 70
+  version: latest
 - title: scale-ai/swe-atlas-tw
   path: registry/scale_ai_swe_atlas_tw.html
   desc: SWE-Atlas - Test Writing -- A benchmark of comprehensive test writing problems for coding agents. Checkout for instructions on running it.

--- a/gen-stderr.txt
+++ b/gen-stderr.txt
@@ -1,5 +1,0 @@
-
-⚠ 1 registry dataset(s) have no override entry in docs/overrides.yml and were auto-stubbed:
-  - scale-ai/swe-atlas-rf
-
-  Fill in `categories:` for each before merging. scripts/validate_overrides.py will block merges on empty stubs.

--- a/gen-stderr.txt
+++ b/gen-stderr.txt
@@ -1,25 +1,5 @@
 
-⚠ 23 dataset(s) could not be resolved to an org on https://registry.harborframework.com and fell back to the search URL:
-  - bfcl_parity@1.0
-  - bird-bench@parity
-  - code-contests@1.0
-  - cooperbench@1.0
-  - gso@1.0
-  - kumo@1.0
-  - kumo@easy
-  - kumo@hard
-  - kumo@parity
-  - ml-dev-bench@1.0
-  - pixiu@parity
-  - researchcodebench@1.0
-  - spider2-dbt@1.0
-  - spreadsheetbench-verified@1.0
-  - swe-lancer-diamond@all
-  - swe-lancer-diamond@ic
-  - swe-lancer-diamond@manager
-  - swebench-verified@1.0
-  - swebench_multilingual@1.0
-  - swesmith@1.0
-  - swtbench-verified@1.0
-  - terminal-bench@2.0
-  - terminal-bench-sample@2.0
+⚠ 1 registry dataset(s) have no override entry in docs/overrides.yml and were auto-stubbed:
+  - scale-ai/swe-atlas-rf
+
+  Fill in `categories:` for each before merging. scripts/validate_overrides.py will block merges on empty stubs.

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2127,6 +2127,37 @@ def scale_ai_swe_atlas_qna(
 
 
 @task
+def scale_ai_swe_atlas_rf(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""SWE-Atlas - Refactoring -- A benchmark of refactoring tasks for coding agents
+
+    Slug: scale-ai/swe-atlas-rf
+    Latest digest: sha256:5f65e33ebd80c3998b2f82d6c78349da1acce1823e4b18e4851f980a03b2ad93
+    """
+    return _harbor_base(
+        package_name="scale-ai/swe-atlas-rf",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def scale_ai_swe_atlas_tw(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,

--- a/stubbed.txt
+++ b/stubbed.txt
@@ -1,0 +1,1 @@
+scale-ai/swe-atlas-rf

--- a/stubbed.txt
+++ b/stubbed.txt
@@ -1,1 +1,0 @@
-scale-ai/swe-atlas-rf


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
scale-ai/swe-atlas-rf
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks