### PR TITLE
chore: quarantine packages newer than 7 days via uv exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ exclude = ["docs/", "tests/"]
 managed = true
 add-bounds = "lower"
 default-groups = ["dev"]
+# Exclude packages published within the last 7 days to protect against supply chain attacks
+exclude-newer = "7 days"
+
+[tool.uv.exclude-newer-package]
+inspect-ai = false
 
 [tool.mypy]
 ignore_missing_imports = false

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,13 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+inspect-ai = false
+
 [[package]]
 name = "aioboto3"
 version = "15.5.0"


### PR DESCRIPTION
- Adds `exclude-newer = "7 days"` under `[tool.uv]` to protect against supply chain attacks — newly published packages are ignored by the resolver until they've been on PyPI for at least 7 days.
- Exempts `inspect-ai` via `[tool.uv.exclude-newer-package]` so the Inspect evals stack can be upgraded immediately when needed.
- Requires uv >= 0.9.17 (relative-duration syntax). CI uses `astral-sh/setup-uv@v8.1.0` which installs latest uv by default, so CI is unaffected. Contributors on older local uv should run `uv self update`.