### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -7,3 +7,6 @@
 - NovitaAI/tb21-*
 - openthoughts/*
 - shogunpurple/9CBCC967-BDAF-43D0-9485-52EBBE4A5094
+# Verbatim copy of agentscope-ai/pawbench (identical 150 inputs, renamed
+# sample ids); keep only the canonical author org.
+- xiaoboai/pawbench

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -907,13 +907,6 @@ webgen-bench/webgen-bench:
   function_name: webgen_bench
   title: WebGen-Bench
 
-xiaoboai/pawbench:
-  categories:
-  - Assistants
-  - Coding
-  title: PawBench
-  repo: https://github.com/agentscope-ai/PawBench
-
 xlang/ds-1000:
   categories:
   - Coding

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -140,6 +140,9 @@ agentic-labs/erp-bench:
   arxiv: https://arxiv.org/abs/2605.26321
   title: ERP-Bench
 
+agentscope-ai/pawbench:
+  categories: []
+
 ai-forever/harness-bench-fast:
   categories:
   - Coding
@@ -587,14 +590,6 @@ openai/swe-lancer-diamond-all:
   desc: 'SWE-Lancer Diamond (full): public split of OpenAI''s SWE-Lancer benchmark — real Upwork freelance software-engineering tasks worth $500,800, combining IC engineering tasks and managerial decision tasks.'
   title: SWE-Lancer Diamond (Full)
 
-openai/swe-lancer-diamond-ic:
-  categories:
-  - Coding
-  arxiv: https://arxiv.org/abs/2502.12115
-  repo: https://github.com/openai/SWELancer-Benchmark
-  desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Individual Contributor (IC) variant: end-to-end engineering tasks.'
-  title: SWE-Lancer Diamond (IC)
-
 openai/swe-lancer-diamond-manager:
   categories:
   - Coding
@@ -690,15 +685,6 @@ satbench/satbench:
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'
   function_name: satbench
   title: SATBench
-
-scale-ai/hil-bench:
-  categories:
-  - Coding
-  - Behavior
-  arxiv: https://arxiv.org/abs/2604.09408
-  repo: https://labs.scale.com/papers/hil
-  desc: 'HiL-Bench (Human-in-the-Loop): tests if agents know when to ask for help rather than proceed with uncertain knowledge.'
-  title: HiL-Bench
 
 scale-ai/swe-atlas-qna:
   categories:
@@ -899,6 +885,9 @@ webgen-bench/webgen-bench:
   repo: https://github.com/mnluzimu/WebGen-Bench
   function_name: webgen_bench
   title: WebGen-Bench
+
+xiaoboai/pawbench:
+  categories: []
 
 xlang/ds-1000:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -141,7 +141,11 @@ agentic-labs/erp-bench:
   title: ERP-Bench
 
 agentscope-ai/pawbench:
-  categories: []
+  categories:
+  - Assistants
+  - Coding
+  title: PawBench
+  repo: https://github.com/agentscope-ai/PawBench
 
 ai-forever/harness-bench-fast:
   categories:
@@ -590,6 +594,14 @@ openai/swe-lancer-diamond-all:
   desc: 'SWE-Lancer Diamond (full): public split of OpenAI''s SWE-Lancer benchmark — real Upwork freelance software-engineering tasks worth $500,800, combining IC engineering tasks and managerial decision tasks.'
   title: SWE-Lancer Diamond (Full)
 
+openai/swe-lancer-diamond-ic:
+  categories:
+  - Coding
+  arxiv: https://arxiv.org/abs/2502.12115
+  repo: https://github.com/openai/SWELancer-Benchmark
+  desc: 'SWE-Lancer Diamond (IC): individual-contributor split of OpenAI''s SWE-Lancer benchmark — real Upwork freelance software-engineering issues fixed in-repo and graded by end-to-end tests.'
+  title: SWE-Lancer Diamond (IC)
+
 openai/swe-lancer-diamond-manager:
   categories:
   - Coding
@@ -685,6 +697,15 @@ satbench/satbench:
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'
   function_name: satbench
   title: SATBench
+
+scale-ai/hil-bench:
+  categories:
+  - Coding
+  - Behavior
+  arxiv: https://arxiv.org/abs/2604.09408
+  repo: https://github.com/hilbenchauthors/hil-bench
+  desc: 'HiL-Bench: software-engineering and text-to-SQL tasks (drawn from SWE-Bench Pro and BIRD) with critical details removed, testing whether an agent recognizes the gap and asks a human for help instead of guessing.'
+  title: HiL-Bench
 
 scale-ai/swe-atlas-qna:
   categories:
@@ -887,7 +908,11 @@ webgen-bench/webgen-bench:
   title: WebGen-Bench
 
 xiaoboai/pawbench:
-  categories: []
+  categories:
+  - Assistants
+  - Coding
+  title: PawBench
+  repo: https://github.com/agentscope-ai/PawBench
 
 xlang/ds-1000:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -112,6 +112,13 @@
   version: latest
   categories:
   - Professional
+- title: agentscope-ai/pawbench
+  path: registry/agentscope_ai_pawbench.html
+  desc: 'PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.'
+  desc_trunc: 'PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use,…'
+  task_function: agentscope_ai_pawbench
+  samples: 150
+  version: latest
 - title: ai-forever/harness-bench-fast
   path: registry/ai_forever_harness_bench_fast.html
   desc: Self-contained file-operation agent benchmark.
@@ -631,15 +638,6 @@
   version: latest
   categories:
   - Coding
-- title: openai/swe-lancer-diamond-ic
-  path: registry/openai_swe_lancer_diamond_ic.html
-  desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Individual Contributor (IC) variant: end-to-end engineering tasks.'
-  desc_trunc: A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in…
-  task_function: openai_swe_lancer_diamond_ic
-  samples: 198
-  version: latest
-  categories:
-  - Coding
 - title: openai/swe-lancer-diamond-manager
   path: registry/openai_swe_lancer_diamond_manager.html
   desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.'
@@ -744,16 +742,6 @@
   version: latest
   categories:
   - Reasoning
-- title: scale-ai/hil-bench
-  path: registry/scale_ai_hil_bench.html
-  desc: 'HiL-Bench (Human-in-the-Loop): tests if agents know when to ask for help rather than proceed with uncertain knowledge.'
-  desc_trunc: 'HiL-Bench (Human-in-the-Loop): tests if agents know when to ask for help rather than proceed with u…'
-  task_function: scale_ai_hil_bench
-  samples: 600
-  version: latest
-  categories:
-  - Coding
-  - Behavior
 - title: scale-ai/swe-atlas-qna
   path: registry/scale_ai_swe_atlas_qna.html
   desc: SWE-Atlas - Codebase QnA is a benchmark of deep codebase comprehension and QnA problems for coding agents. Checkout for instructions on running it.
@@ -976,6 +964,13 @@
   version: latest
   categories:
   - Coding
+- title: xiaoboai/pawbench
+  path: registry/xiaoboai_pawbench.html
+  desc: 'PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.'
+  desc_trunc: 'PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use,…'
+  task_function: xiaoboai_pawbench
+  samples: 150
+  version: latest
 - title: xlang/ds-1000
   path: registry/xlang_ds_1000.html
   desc: 'DS-1000: data-science code-generation problems from StackOverflow across NumPy, Pandas, TensorFlow, PyTorch, SciPy, Scikit-learn, and Matplotlib, with execution-based grading.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -119,6 +119,9 @@
   task_function: agentscope_ai_pawbench
   samples: 150
   version: latest
+  categories:
+  - Assistants
+  - Coding
 - title: ai-forever/harness-bench-fast
   path: registry/ai_forever_harness_bench_fast.html
   desc: Self-contained file-operation agent benchmark.
@@ -638,6 +641,15 @@
   version: latest
   categories:
   - Coding
+- title: openai/swe-lancer-diamond-ic
+  path: registry/openai_swe_lancer_diamond_ic.html
+  desc: 'SWE-Lancer Diamond (IC): individual-contributor split of OpenAI''s SWE-Lancer benchmark — real Upwork freelance software-engineering issues fixed in-repo and graded by end-to-end tests.'
+  desc_trunc: 'SWE-Lancer Diamond (IC): individual-contributor split of OpenAI''s SWE-Lancer benchmark — real Upwor…'
+  task_function: openai_swe_lancer_diamond_ic
+  samples: 198
+  version: latest
+  categories:
+  - Coding
 - title: openai/swe-lancer-diamond-manager
   path: registry/openai_swe_lancer_diamond_manager.html
   desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.'
@@ -742,6 +754,16 @@
   version: latest
   categories:
   - Reasoning
+- title: scale-ai/hil-bench
+  path: registry/scale_ai_hil_bench.html
+  desc: 'HiL-Bench: software-engineering and text-to-SQL tasks (drawn from SWE-Bench Pro and BIRD) with critical details removed, testing whether an agent recognizes the gap and asks a human for help instead of guessing.'
+  desc_trunc: 'HiL-Bench: software-engineering and text-to-SQL tasks (drawn from SWE-Bench Pro and BIRD) with crit…'
+  task_function: scale_ai_hil_bench
+  samples: 600
+  version: latest
+  categories:
+  - Coding
+  - Behavior
 - title: scale-ai/swe-atlas-qna
   path: registry/scale_ai_swe_atlas_qna.html
   desc: SWE-Atlas - Codebase QnA is a benchmark of deep codebase comprehension and QnA problems for coding agents. Checkout for instructions on running it.
@@ -971,6 +993,9 @@
   task_function: xiaoboai_pawbench
   samples: 150
   version: latest
+  categories:
+  - Assistants
+  - Coding
 - title: xlang/ds-1000
   path: registry/xlang_ds_1000.html
   desc: 'DS-1000: data-science code-generation problems from StackOverflow across NumPy, Pandas, TensorFlow, PyTorch, SciPy, Scikit-learn, and Matplotlib, with execution-based grading.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -986,16 +986,6 @@
   version: latest
   categories:
   - Coding
-- title: xiaoboai/pawbench
-  path: registry/xiaoboai_pawbench.html
-  desc: 'PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.'
-  desc_trunc: 'PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use,…'
-  task_function: xiaoboai_pawbench
-  samples: 150
-  version: latest
-  categories:
-  - Assistants
-  - Coding
 - title: xlang/ds-1000
   path: registry/xlang_ds_1000.html
   desc: 'DS-1000: data-science code-generation problems from StackOverflow across NumPy, Pandas, TensorFlow, PyTorch, SciPy, Scikit-learn, and Matplotlib, with execution-based grading.'

--- a/scripts/generate_tasks.py
+++ b/scripts/generate_tasks.py
@@ -113,6 +113,13 @@ def scrape_hub_slugs() -> set[tuple[str, str]]:
     pairs: set[tuple[str, str]] = set()
     pages_scraped = 0
     href_pattern = re.compile(r"/datasets/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)")
+    # The hub streams its payload as Next.js Flight chunks: a single dataset
+    # href can be split across a `</script><script>self.__next_f.push([N,"`
+    # boundary (e.g. `/datasets/scale-ai/hil-b"]) ... push([1,"ench`), which
+    # both fabricates a truncated slug (`hil-b`) and hides the real one
+    # (`hil-bench`). Strip the inter-chunk boilerplate to rejoin the string
+    # before matching.
+    chunk_boundary = re.compile(r'"\]\)</script><script>self\.__next_f\.push\(\[\d+,"')
 
     for page in range(1, REGISTRY_SITE_MAX_PAGES + 1):
         url = f"{REGISTRY_SITE_BASE}/datasets?page={page}"
@@ -121,7 +128,7 @@ def scrape_hub_slugs() -> set[tuple[str, str]]:
             lambda url=url: curl_get(url, max_time=60),
         ).decode()
         pages_scraped = page
-        new_pairs = set(href_pattern.findall(body))
+        new_pairs = set(href_pattern.findall(chunk_boundary.sub("", body)))
         if not new_pairs - pairs:
             break
         pairs |= new_pairs

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2059,6 +2059,37 @@ def openai_swe_lancer_diamond_all(
 
 
 @task
+def openai_swe_lancer_diamond_ic(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""SWE-Lancer Diamond (IC): individual-contributor split of OpenAI's SWE-Lancer benchmark — real Upwork freelance software-engineering issues fixed in-repo and graded by end-to-end tests.
+
+    Slug: openai/swe-lancer-diamond-ic
+    Latest digest: sha256:d0645e1152d417dd3ec8b36c324c03a8729b3fa48c8840f8935f93582c4dce28
+    """
+    return _harbor_base(
+        package_name="openai/swe-lancer-diamond-ic",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def openai_swe_lancer_diamond_manager(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2393,6 +2424,37 @@ def satbench(
     """
     return _harbor_base(
         package_name="satbench/satbench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def scale_ai_hil_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""HiL-Bench: software-engineering and text-to-SQL tasks (drawn from SWE-Bench Pro and BIRD) with critical details removed, testing whether an agent recognizes the gap and asks a human for help instead of guessing.
+
+    Slug: scale-ai/hil-bench
+    Latest digest: sha256:a308c71edf51736003412b8353cfb25f0cdfd58065535e18e2e8937fe6f7ac42
+    """
+    return _harbor_base(
+        package_name="scale-ai/hil-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -354,6 +354,37 @@ def agentic_labs_erp_bench(
 
 
 @task
+def agentscope_ai_pawbench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.
+
+    Slug: agentscope-ai/pawbench
+    Latest digest: sha256:a4197a2fe40bf045abad4ea2ab1037bf9c8bdfab01c378fdcc2b40242f5d63dd
+    """
+    return _harbor_base(
+        package_name="agentscope-ai/pawbench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def ai_forever_harness_bench_fast(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2028,37 +2059,6 @@ def openai_swe_lancer_diamond_all(
 
 
 @task
-def openai_swe_lancer_diamond_ic(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Individual Contributor (IC) variant: end-to-end engineering tasks.
-
-    Slug: openai/swe-lancer-diamond-ic
-    Latest digest: sha256:d0645e1152d417dd3ec8b36c324c03a8729b3fa48c8840f8935f93582c4dce28
-    """
-    return _harbor_base(
-        package_name="openai/swe-lancer-diamond-ic",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def openai_swe_lancer_diamond_manager(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2393,37 +2393,6 @@ def satbench(
     """
     return _harbor_base(
         package_name="satbench/satbench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def scale_ai_hil_bench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""HiL-Bench (Human-in-the-Loop): tests if agents know when to ask for help rather than proceed with uncertain knowledge.
-
-    Slug: scale-ai/hil-bench
-    Latest digest: sha256:a308c71edf51736003412b8353cfb25f0cdfd58065535e18e2e8937fe6f7ac42
-    """
-    return _harbor_base(
-        package_name="scale-ai/hil-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -3137,6 +3106,37 @@ def webgen_bench(
     """
     return _harbor_base(
         package_name="webgen-bench/webgen-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def xiaoboai_pawbench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.
+
+    Slug: xiaoboai/pawbench
+    Latest digest: sha256:6ad7947e6a9a6dcb17b13df7bb322226187facdef24438afee3921a12c828a5d
+    """
+    return _harbor_base(
+        package_name="xiaoboai/pawbench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3181,37 +3181,6 @@ def webgen_bench(
 
 
 @task
-def xiaoboai_pawbench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.
-
-    Slug: xiaoboai/pawbench
-    Latest digest: sha256:6ad7947e6a9a6dcb17b13df7bb322226187facdef24438afee3921a12c828a5d
-    """
-    return _harbor_base(
-        package_name="xiaoboai/pawbench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def xlang_ds_1000(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
agentscope-ai/pawbench
xiaoboai/pawbench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks