### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -422,7 +422,12 @@ grafana/o11y-bench:
   repo: https://github.com/grafana/o11y-bench
 
 grandsmile/unicode:
-  categories: []
+  categories:
+  - Coding
+  arxiv: https://arxiv.org/abs/2510.17868
+  repo: https://github.com/grandsmile/UniCode
+  desc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.'
+  title: UniCode
 
 harbor/rewardhackbench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -421,6 +421,9 @@ grafana/o11y-bench:
   - Professional
   repo: https://github.com/grafana/o11y-bench
 
+grandsmile/unicode:
+  categories: []
+
 harbor/rewardhackbench:
   categories:
   - Safeguards

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -439,6 +439,13 @@
   categories:
   - Coding
   - Professional
+- title: grandsmile/unicode
+  path: registry/grandsmile_unicode.html
+  desc: UniCode generative coding benchmark adapted to Harbor. Oracle-verified subset with valid_codes-derived solutions.
+  desc_trunc: UniCode generative coding benchmark adapted to Harbor. Oracle-verified subset with valid_codes-deri…
+  task_function: grandsmile_unicode
+  samples: 399
+  version: latest
 - title: harbor/rewardhackbench
   path: registry/harbor_rewardhackbench.html
   desc: 'RewardHackBench: judge benchmark for detecting reward hacking in agent trajectories — each trace is labelled for harness-level cheating, task-level reward hacking, and refusals.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -441,11 +441,13 @@
   - Professional
 - title: grandsmile/unicode
   path: registry/grandsmile_unicode.html
-  desc: UniCode generative coding benchmark adapted to Harbor. Oracle-verified subset with valid_codes-derived solutions.
-  desc_trunc: UniCode generative coding benchmark adapted to Harbor. Oracle-verified subset with valid_codes-deri…
+  desc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.'
+  desc_trunc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe g…'
   task_function: grandsmile_unicode
   samples: 399
   version: latest
+  categories:
+  - Coding
 - title: harbor/rewardhackbench
   path: registry/harbor_rewardhackbench.html
   desc: 'RewardHackBench: judge benchmark for detecting reward hacking in agent trajectories — each trace is labelled for harness-level cheating, task-level reward hacking, and refusals.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1419,7 +1419,7 @@ def grandsmile_unicode(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""UniCode generative coding benchmark adapted to Harbor. Oracle-verified subset with valid_codes-derived solutions.
+    r"""UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.
 
     Slug: grandsmile/unicode
     Latest digest: sha256:7089553ec020ab38347293a5575c916c9ca490f8398d527da93873b4bc766f2b

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1408,6 +1408,37 @@ def grafana_o11y_bench(
 
 
 @task
+def grandsmile_unicode(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""UniCode generative coding benchmark adapted to Harbor. Oracle-verified subset with valid_codes-derived solutions.
+
+    Slug: grandsmile/unicode
+    Latest digest: sha256:7089553ec020ab38347293a5575c916c9ca490f8398d527da93873b4bc766f2b
+    """
+    return _harbor_base(
+        package_name="grandsmile/unicode",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def harbor_rewardhackbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
grandsmile/unicode
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks