### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/.claude/skills/nightly-pr-triage/SKILL.md
+++ b/.claude/skills/nightly-pr-triage/SKILL.md
@@ -39,9 +39,40 @@ org/name:
   categories: []
 ```
 
-### 3. Research each new dataset
+### 3. Triage each stub: keep, exclude, or dedupe
 
-For each slug, gather:
+Not every auto-stubbed slug is a real benchmark worth listing. Before researching, decide for each stub whether it should be **kept** (→ research + fill, the common case), **excluded** (junk), or **deduped** (a copy of one we already list). Excluded/deduped slugs go in `docs/exclude.yml` instead of getting `categories` filled in.
+
+> The live scrape in step 6 (`validate_overrides.py`) often surfaces *more* new slugs than the PR description lists — datasets land on the hub after the nightly bot ran. Triage those the same way. Run validate early to see the full set.
+
+**Exclude experimental / personal junk.** People push half-finished or personal tasks to the hub that aren't published benchmarks. Tells:
+- Slug looks like a working file, not a release: `task1_v3_1_...`, `..._train_patched` / `..._eval_patched`, version/scratch suffixes (`-v1`, `-rolling`).
+- `desc` reads like an internal dev note, e.g. `"Patched verifier rebuild: reworked Modal capability-contract checks ... Tasks identical except tests/verify.py."`
+- Tiny task count (a handful of samples) with a generic name.
+- The org is an **individual**, not a project/company. Check it:
+  ```bash
+  gh api users/<org> -q '.type + " | " + (.name // "") + " | repos=" + (.public_repos|tostring)'
+  ```
+  `type=User` (a person) with no matching benchmark repo is a strong exclude signal; `type=Organization` (or a User whose repo *is* the canonical benchmark) is a keep signal. A slug whose org doesn't resolve at all (`404`) and reads like a dev artifact is junk.
+
+When in doubt about whether something is a real benchmark vs. junk, ask the user before excluding.
+
+**Dedupe copies published under multiple orgs.** The same benchmark sometimes appears under several org slugs (verbatim re-uploads). Keep the copy from the **most credible / original author** — the benchmark's actual authors, or the org that owns the upstream GitHub repo — and exclude the rest. Confirm they're really the same before dropping one:
+```bash
+uv run python -c "
+from inspect_harbor import <func_a>, <func_b>
+a, b = <func_a>().dataset, <func_b>().dataset
+print('counts:', len(a), len(b))
+print('inputs identical:', sorted(s.input for s in a) == sorted(s.input for s in b))
+"
+```
+Identical inputs (even if sample ids are renamed) ⇒ duplicate. Example: `xiaoboai/pawbench` is a verbatim copy of `agentscope-ai/pawbench` (same 150 inputs, renamed ids) — we keep `agentscope-ai` (the author org that owns the PawBench repo) and exclude `xiaoboai/pawbench`.
+
+**How to exclude.** Add a glob to `docs/exclude.yml` with a one-line comment saying *why*, prefer an org-wide glob (`ashantanu/*`, `vmax-modal/*`) for a junk account and an exact slug (`xiaoboai/pawbench`) for a single dedup. Then drop any stub the bot already added to `docs/overrides.yml` (pop it in the helper from step 5, or it'll linger as an orphan-warning). After regenerating, the slug disappears from `_tasks.py` and the listing. See the header of `docs/exclude.yml` for the existing patterns.
+
+### 4. Research each new dataset
+
+For each slug you're keeping, gather:
 
 | Field | Where to find it |
 |---|---|
@@ -90,7 +121,7 @@ Read the `desc` for every slug you're filling in categories for — it's publish
 
 When you do rewrite, aim for one sentence that says **what the model is asked to do and in what domain** — concrete enough that a reader scanning the listing knows whether the benchmark is relevant. If the default is uninformative, inspect a task input (the one-liner above) to learn what the task really is, then write from that. Example: for `ivanleo/agent-search`, the task loads a docs SQLite DB and asks the agent to answer API questions by writing queries — so a fitting `desc` is `"Agent answers Gemini API questions by querying an indexed documentation database."` rather than the shipped placeholder.
 
-### 4. Apply the overrides
+### 5. Apply the overrides
 
 Use the in-script helpers — they preserve the file's header comment and field order:
 
@@ -110,7 +141,7 @@ write_overrides_file(overrides)
 "
 ```
 
-### 5. Validate, regenerate, format, test
+### 6. Validate, regenerate, format, test
 
 ```bash
 uv run python scripts/validate_overrides.py    # CI's gate; must report all valid
@@ -119,11 +150,11 @@ make check                                     # ruff (fixes _tasks.py docstring
 uv run pytest tests/ --no-header               # 167+ tests; should be 100% pass
 ```
 
-### 6. Commit and push
+### 7. Commit and push
 
 The bot's own commit on the branch already says `fix: update Harbor registry tasks`. Your commit can be the same or `fix: fill in categories for <new datasets>`. Push to `origin update-harbor-tasks`.
 
-### 7. After merge: publish the docs site
+### 8. After merge: publish the docs site
 
 The user merges the PR. Docs at https://meridianlabs-ai.github.io/inspect_harbor are not auto-published — the new datasets won't show up on the registry listing until someone re-renders + pushes `gh-pages`. Do it as soon as the merge lands so the public docs catch up:
 

--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -10,3 +10,10 @@
 # Verbatim copy of agentscope-ai/pawbench (identical 150 inputs, renamed
 # sample ids); keep only the canonical author org.
 - xiaoboai/pawbench
+# Individual's experimental personal tasks, not a published benchmark
+# (e.g. task1_v3_1_stock_research_basket_rolling).
+- ashantanu/*
+# Experimental Modal-platform port iterations ("patched verifier rebuild",
+# train/eval splits); not a published benchmark and not a real org. The
+# canonical vmax dataset is kept as vmax/vmax-tasks.
+- vmax-modal/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -199,6 +199,12 @@ arcprize/arc-agi-2:
   title: ARC-AGI-2
   featured: true
 
+ashantanu/task1_v3_1_stock_research_basket_rolling:
+  categories: []
+
+benchflow/skillsbench:
+  categories: []
+
 bigcode/bigcodebench-hard-complete:
   categories:
   - Coding

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -199,11 +199,12 @@ arcprize/arc-agi-2:
   title: ARC-AGI-2
   featured: true
 
-ashantanu/task1_v3_1_stock_research_basket_rolling:
-  categories: []
-
 benchflow/skillsbench:
-  categories: []
+  categories:
+  - Assistants
+  repo: https://github.com/benchflow-ai/skillsbench
+  desc: 'SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folders of instructions, scripts, and resources) to complete specialized workflows spanning science, engineering, and professional domains.'
+  title: SkillsBench
 
 bigcode/bigcodebench-hard-complete:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -180,20 +180,15 @@
   categories:
   - Reasoning
   - Multimodal
-- title: ashantanu/task1_v3_1_stock_research_basket_rolling
-  path: registry/ashantanu_task1_v3_1_stock_research_basket_rolling.html
-  desc: 'Task 1 v3.1: eight rolling as-of stock research basket tasks for repeated model trajectories.'
-  desc_trunc: 'Task 1 v3.1: eight rolling as-of stock research basket tasks for repeated model trajectories.'
-  task_function: ashantanu_task1_v3_1_stock_research_basket_rolling
-  samples: 8
-  version: latest
 - title: benchflow/skillsbench
   path: registry/benchflow_skillsbench.html
-  desc: SkillsBench v1.1 — 87-task benchmark snapshot.
-  desc_trunc: SkillsBench v1.1 — 87-task benchmark snapshot.
+  desc: 'SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folders of instructions, scripts, and resources) to complete specialized workflows spanning science, engineering, and professional domains.'
+  desc_trunc: 'SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folde…'
   task_function: benchflow_skillsbench
   samples: 87
   version: latest
+  categories:
+  - Assistants
 - title: bigcode/bigcodebench-hard-complete
   path: registry/bigcode_bigcodebench_hard_complete.html
   desc: 'BigCodeBench-Hard (Complete split): hard subset evaluating LLMs on code generation with diverse function calls and complex instructions, in completion format.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -180,6 +180,20 @@
   categories:
   - Reasoning
   - Multimodal
+- title: ashantanu/task1_v3_1_stock_research_basket_rolling
+  path: registry/ashantanu_task1_v3_1_stock_research_basket_rolling.html
+  desc: 'Task 1 v3.1: eight rolling as-of stock research basket tasks for repeated model trajectories.'
+  desc_trunc: 'Task 1 v3.1: eight rolling as-of stock research basket tasks for repeated model trajectories.'
+  task_function: ashantanu_task1_v3_1_stock_research_basket_rolling
+  samples: 8
+  version: latest
+- title: benchflow/skillsbench
+  path: registry/benchflow_skillsbench.html
+  desc: SkillsBench v1.1 — 87-task benchmark snapshot.
+  desc_trunc: SkillsBench v1.1 — 87-task benchmark snapshot.
+  task_function: benchflow_skillsbench
+  samples: 87
+  version: latest
 - title: bigcode/bigcodebench-hard-complete
   path: registry/bigcode_bigcodebench_hard_complete.html
   desc: 'BigCodeBench-Hard (Complete split): hard subset evaluating LLMs on code generation with diverse function calls and complex instructions, in completion format.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -571,6 +571,68 @@ def arcprize_arc_agi_2(
 
 
 @task
+def ashantanu_task1_v3_1_stock_research_basket_rolling(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Task 1 v3.1: eight rolling as-of stock research basket tasks for repeated model trajectories.
+
+    Slug: ashantanu/task1_v3_1_stock_research_basket_rolling
+    Latest digest: sha256:ff2fc96ae5e3f92c6ee54fc3f96d5a4de43d70e3c18b274d37144de8bd9b62bc
+    """
+    return _harbor_base(
+        package_name="ashantanu/task1_v3_1_stock_research_basket_rolling",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def benchflow_skillsbench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""SkillsBench v1.1 — 87-task benchmark snapshot
+
+    Slug: benchflow/skillsbench
+    Latest digest: sha256:145925c10bc09425dc0201772cfa50d9b800010081cf5ad77969554a644d7ae1
+    """
+    return _harbor_base(
+        package_name="benchflow/skillsbench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def bigcode_bigcodebench_hard_complete(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -571,37 +571,6 @@ def arcprize_arc_agi_2(
 
 
 @task
-def ashantanu_task1_v3_1_stock_research_basket_rolling(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Task 1 v3.1: eight rolling as-of stock research basket tasks for repeated model trajectories.
-
-    Slug: ashantanu/task1_v3_1_stock_research_basket_rolling
-    Latest digest: sha256:ff2fc96ae5e3f92c6ee54fc3f96d5a4de43d70e3c18b274d37144de8bd9b62bc
-    """
-    return _harbor_base(
-        package_name="ashantanu/task1_v3_1_stock_research_basket_rolling",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def benchflow_skillsbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -613,7 +582,7 @@ def benchflow_skillsbench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""SkillsBench v1.1 — 87-task benchmark snapshot
+    r"""SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folders of instructions, scripts, and resources) to complete specialized workflows spanning science, engineering, and professional domains.
 
     Slug: benchflow/skillsbench
     Latest digest: sha256:145925c10bc09425dc0201772cfa50d9b800010081cf5ad77969554a644d7ae1


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
ashantanu/task1_v3_1_stock_research_basket_rolling
benchflow/skillsbench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks