### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -17,3 +17,7 @@
 # train/eval splits); not a published benchmark and not a real org. The
 # canonical vmax dataset is kept as vmax/vmax-tasks.
 - vmax-modal/*
+# Verbatim duplicate of orinlabs/horizon-public (identical 3-task public
+# example set, same sample ids); keep the canonical name matching the
+# orinlabs/horizon repo and "Horizon" brand.
+- orinlabs/horizon-1-public

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -436,12 +436,6 @@ grandsmile/unicode:
   desc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.'
   title: UniCode
 
-harbor/rewardhackbench:
-  categories:
-  - Safeguards
-  title: RewardHackBench
-  desc: 'RewardHackBench: judge benchmark for detecting reward hacking in agent trajectories — each trace is labelled for harness-level cheating, task-level reward hacking, and refusals.'
-
 harveyai/lab:
   categories:
   - Law
@@ -625,6 +619,12 @@ openai/swe-lancer-diamond-manager:
   repo: https://github.com/openai/SWELancer-Benchmark
   desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.'
   title: SWE-Lancer Diamond (Manager)
+
+orinlabs/horizon-1-public:
+  categories: []
+
+orinlabs/horizon-public:
+  categories: []
 
 pgcodellm/rebench-v2-test:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -620,11 +620,12 @@ openai/swe-lancer-diamond-manager:
   desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.'
   title: SWE-Lancer Diamond (Manager)
 
-orinlabs/horizon-1-public:
-  categories: []
-
 orinlabs/horizon-public:
-  categories: []
+  categories:
+  - Assistants
+  repo: https://github.com/orinlabs/horizon
+  desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'
+  title: Horizon
 
 pgcodellm/rebench-v2-test:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -669,20 +669,15 @@
   categories:
   - Coding
   - Professional
-- title: orinlabs/horizon-1-public
-  path: registry/orinlabs_horizon_1_public.html
-  desc: 'Horizon-1 sample set: continual-learning eval tasks.'
-  desc_trunc: 'Horizon-1 sample set: continual-learning eval tasks.'
-  task_function: orinlabs_horizon_1_public
-  samples: 3
-  version: latest
 - title: orinlabs/horizon-public
   path: registry/orinlabs_horizon_public.html
-  desc: 'Horizon sample set: continual-learning eval tasks.'
-  desc_trunc: 'Horizon sample set: continual-learning eval tasks.'
+  desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'
+  desc_trunc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agen…'
   task_function: orinlabs_horizon_public
   samples: 3
   version: latest
+  categories:
+  - Assistants
 - title: pgcodellm/rebench-v2-test
   path: registry/pgcodellm_rebench_v2_test.html
   desc: 'SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -457,15 +457,6 @@
   version: latest
   categories:
   - Coding
-- title: harbor/rewardhackbench
-  path: registry/harbor_rewardhackbench.html
-  desc: 'RewardHackBench: judge benchmark for detecting reward hacking in agent trajectories — each trace is labelled for harness-level cheating, task-level reward hacking, and refusals.'
-  desc_trunc: 'RewardHackBench: judge benchmark for detecting reward hacking in agent trajectories — each trace is…'
-  task_function: harbor_rewardhackbench
-  samples: 846
-  version: latest
-  categories:
-  - Safeguards
 - title: harveyai/lab
   path: registry/harveyai_lab.html
   desc: Harvey LAB - open-source benchmark for evaluating agents on real legal work.
@@ -678,6 +669,20 @@
   categories:
   - Coding
   - Professional
+- title: orinlabs/horizon-1-public
+  path: registry/orinlabs_horizon_1_public.html
+  desc: 'Horizon-1 sample set: continual-learning eval tasks.'
+  desc_trunc: 'Horizon-1 sample set: continual-learning eval tasks.'
+  task_function: orinlabs_horizon_1_public
+  samples: 3
+  version: latest
+- title: orinlabs/horizon-public
+  path: registry/orinlabs_horizon_public.html
+  desc: 'Horizon sample set: continual-learning eval tasks.'
+  desc_trunc: 'Horizon sample set: continual-learning eval tasks.'
+  task_function: orinlabs_horizon_public
+  samples: 3
+  version: latest
 - title: pgcodellm/rebench-v2-test
   path: registry/pgcodellm_rebench_v2_test.html
   desc: 'SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2152,37 +2152,6 @@ def openai_swe_lancer_diamond_manager(
 
 
 @task
-def orinlabs_horizon_1_public(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Horizon-1 sample set: continual-learning eval tasks
-
-    Slug: orinlabs/horizon-1-public
-    Latest digest: sha256:287020956d173bf2478bd7fab1aa479eaf6e4912e75bb4d363a21efabb42f37a
-    """
-    return _harbor_base(
-        package_name="orinlabs/horizon-1-public",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def orinlabs_horizon_public(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2194,7 +2163,7 @@ def orinlabs_horizon_public(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""Horizon sample set: continual-learning eval tasks
+    r"""Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.
 
     Slug: orinlabs/horizon-public
     Latest digest: sha256:38204787d8cd258d35e620e639c4418e4805141f22dc752b5e09431d0a3dd552

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1470,37 +1470,6 @@ def grandsmile_unicode(
 
 
 @task
-def harbor_rewardhackbench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""RewardHackBench: judge benchmark for detecting reward hacking in agent trajectories — each trace is labelled for harness-level cheating, task-level reward hacking, and refusals.
-
-    Slug: harbor/rewardhackbench
-    Latest digest: sha256:0dd16e1029495cba180809b7ecfbae375089881b11ff11e369bfbbf3c72a2fd8
-    """
-    return _harbor_base(
-        package_name="harbor/rewardhackbench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def harveyai_lab(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2170,6 +2139,68 @@ def openai_swe_lancer_diamond_manager(
     """
     return _harbor_base(
         package_name="openai/swe-lancer-diamond-manager",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def orinlabs_horizon_1_public(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Horizon-1 sample set: continual-learning eval tasks
+
+    Slug: orinlabs/horizon-1-public
+    Latest digest: sha256:287020956d173bf2478bd7fab1aa479eaf6e4912e75bb4d363a21efabb42f37a
+    """
+    return _harbor_base(
+        package_name="orinlabs/horizon-1-public",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def orinlabs_horizon_public(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Horizon sample set: continual-learning eval tasks
+
+    Slug: orinlabs/horizon-public
+    Latest digest: sha256:38204787d8cd258d35e620e639c4418e4805141f22dc752b5e09431d0a3dd552
+    """
+    return _harbor_base(
+        package_name="orinlabs/horizon-public",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
orinlabs/horizon-1-public
orinlabs/horizon-public
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks