### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -21,3 +21,7 @@
 # example set, same sample ids); keep the canonical name matching the
 # orinlabs/horizon repo and "Horizon" brand.
 - orinlabs/horizon-1-public
+# Individual's (handle-named) project with no public benchmark repo, no
+# paper, and no external footprint; all the user's repos are forks of other
+# projects. Includes a -trial upload-test subset. Not a published benchmark.
+- tmax/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -453,6 +453,12 @@ ineqmath/ineqmath:
   function_name: ineqmath
   title: IneqMath
 
+islo-labs/reward-hack-bench:
+  categories: []
+
+islo-labs/reward-hack-bench-control:
+  categories: []
+
 ivanleo/agent-search:
   categories:
   - Coding
@@ -889,6 +895,15 @@ thetalab/vector-edit-gym:
   - Coding
   - Multimodal
   title: Vector Edit Gym
+
+tinycomputerai/bun-server-bench:
+  categories: []
+
+tmax/TMax-15K-Harbor:
+  categories: []
+
+tmax/TMax-15K-Harbor-trial:
+  categories: []
 
 usaco/usaco:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -454,10 +454,16 @@ ineqmath/ineqmath:
   title: IneqMath
 
 islo-labs/reward-hack-bench:
-  categories: []
+  categories:
+  - Safeguards
+  repo: https://github.com/islo-labs/reward-hack-bench
+  title: Reward-Hack-Bench
 
 islo-labs/reward-hack-bench-control:
-  categories: []
+  categories:
+  - Safeguards
+  repo: https://github.com/islo-labs/reward-hack-bench
+  title: Reward-Hack-Bench (Control)
 
 ivanleo/agent-search:
   categories:
@@ -897,13 +903,9 @@ thetalab/vector-edit-gym:
   title: Vector Edit Gym
 
 tinycomputerai/bun-server-bench:
-  categories: []
-
-tmax/TMax-15K-Harbor:
-  categories: []
-
-tmax/TMax-15K-Harbor-trial:
-  categories: []
+  categories:
+  - Coding
+  repo: https://github.com/tinycomputerai/bun-server-bench
 
 usaco/usaco:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -477,6 +477,20 @@
   categories:
   - Mathematics
   - Reasoning
+- title: islo-labs/reward-hack-bench
+  path: registry/islo_labs_reward_hack_bench.html
+  desc: 'Reward-hacking benchmark: SWE-bench + CyBench tasks with injected solution-retrieval cheat prompts, scored by a fairness LLM judge. Reward = solved without cheating.'
+  desc_trunc: 'Reward-hacking benchmark: SWE-bench + CyBench tasks with injected solution-retrieval cheat prompts,…'
+  task_function: islo_labs_reward_hack_bench
+  samples: 8
+  version: latest
+- title: islo-labs/reward-hack-bench-control
+  path: registry/islo_labs_reward_hack_bench_control.html
+  desc: 'Baseline/control companion to reward-hack-bench: the same 8 SWE-bench + CyBench tasks with NO cheat prompt, still scored by the fairness judge. Also packages these CyBench/GlacierCTF tasks as Harbor tasks.'
+  desc_trunc: 'Baseline/control companion to reward-hack-bench: the same 8 SWE-bench + CyBench tasks with NO cheat…'
+  task_function: islo_labs_reward_hack_bench_control
+  samples: 8
+  version: latest
 - title: ivanleo/agent-search
   path: registry/ivanleo_agent_search.html
   desc: Agent answers Gemini API questions by querying an indexed documentation database.
@@ -966,6 +980,27 @@
   categories:
   - Coding
   - Multimodal
+- title: tinycomputerai/bun-server-bench
+  path: registry/tinycomputerai_bun_server_bench.html
+  desc: 'bun-server-bench: a correctness benchmark of 50 production-shaped Bun server engineering tasks for evaluating AI coding agents.'
+  desc_trunc: 'bun-server-bench: a correctness benchmark of 50 production-shaped Bun server engineering tasks for…'
+  task_function: tinycomputerai_bun_server_bench
+  samples: 50
+  version: latest
+- title: tmax/TMax-15K-Harbor
+  path: registry/tmax_tmax_15k_harbor.html
+  desc: '15k compositional terminal-agent tasks: legacy 10k (self-contained) + v2 5k (intricate, multimodal fixtures). Programmatic verifier per task.'
+  desc_trunc: '15k compositional terminal-agent tasks: legacy 10k (self-contained) + v2 5k (intricate, multimodal…'
+  task_function: tmax_tmax_15k_harbor
+  samples: 1000
+  version: latest
+- title: tmax/TMax-15K-Harbor-trial
+  path: registry/tmax_tmax_15k_harbor_trial.html
+  desc: 'Trial subset (12 tasks) of TMax-15K-Harbor: compositional terminal-agent tasks (legacy + v2 intricate w/ multimodal fixtures).'
+  desc_trunc: 'Trial subset (12 tasks) of TMax-15K-Harbor: compositional terminal-agent tasks (legacy + v2 intrica…'
+  task_function: tmax_tmax_15k_harbor_trial
+  samples: 12
+  version: latest
 - title: usaco/usaco
   path: registry/usaco.html
   desc: 'USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -484,6 +484,8 @@
   task_function: islo_labs_reward_hack_bench
   samples: 8
   version: latest
+  categories:
+  - Safeguards
 - title: islo-labs/reward-hack-bench-control
   path: registry/islo_labs_reward_hack_bench_control.html
   desc: 'Baseline/control companion to reward-hack-bench: the same 8 SWE-bench + CyBench tasks with NO cheat prompt, still scored by the fairness judge. Also packages these CyBench/GlacierCTF tasks as Harbor tasks.'
@@ -491,6 +493,8 @@
   task_function: islo_labs_reward_hack_bench_control
   samples: 8
   version: latest
+  categories:
+  - Safeguards
 - title: ivanleo/agent-search
   path: registry/ivanleo_agent_search.html
   desc: Agent answers Gemini API questions by querying an indexed documentation database.
@@ -987,20 +991,8 @@
   task_function: tinycomputerai_bun_server_bench
   samples: 50
   version: latest
-- title: tmax/TMax-15K-Harbor
-  path: registry/tmax_tmax_15k_harbor.html
-  desc: '15k compositional terminal-agent tasks: legacy 10k (self-contained) + v2 5k (intricate, multimodal fixtures). Programmatic verifier per task.'
-  desc_trunc: '15k compositional terminal-agent tasks: legacy 10k (self-contained) + v2 5k (intricate, multimodal…'
-  task_function: tmax_tmax_15k_harbor
-  samples: 1000
-  version: latest
-- title: tmax/TMax-15K-Harbor-trial
-  path: registry/tmax_tmax_15k_harbor_trial.html
-  desc: 'Trial subset (12 tasks) of TMax-15K-Harbor: compositional terminal-agent tasks (legacy + v2 intricate w/ multimodal fixtures).'
-  desc_trunc: 'Trial subset (12 tasks) of TMax-15K-Harbor: compositional terminal-agent tasks (legacy + v2 intrica…'
-  task_function: tmax_tmax_15k_harbor_trial
-  samples: 12
-  version: latest
+  categories:
+  - Coding
 - title: usaco/usaco
   path: registry/usaco.html
   desc: 'USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1532,6 +1532,68 @@ def ineqmath(
 
 
 @task
+def islo_labs_reward_hack_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Reward-hacking benchmark: SWE-bench + CyBench tasks with injected solution-retrieval cheat prompts, scored by a fairness LLM judge. Reward = solved without cheating.
+
+    Slug: islo-labs/reward-hack-bench
+    Latest digest: sha256:d121319dcb3e7b2606a52706c73d1926eb20c1fa8d0a473137ea9217d4943053
+    """
+    return _harbor_base(
+        package_name="islo-labs/reward-hack-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def islo_labs_reward_hack_bench_control(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Baseline/control companion to reward-hack-bench: the same 8 SWE-bench + CyBench tasks with NO cheat prompt, still scored by the fairness judge. Also packages these CyBench/GlacierCTF tasks as Harbor tasks.
+
+    Slug: islo-labs/reward-hack-bench-control
+    Latest digest: sha256:99138aaa3bec4e5fccc5a3c63b547604320d70b754aafbb5389660c202f37332
+    """
+    return _harbor_base(
+        package_name="islo-labs/reward-hack-bench-control",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def ivanleo_agent_search(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3106,6 +3168,99 @@ def thetalab_vector_edit_gym(
     """
     return _harbor_base(
         package_name="thetalab/vector-edit-gym",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def tinycomputerai_bun_server_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""bun-server-bench: a correctness benchmark of 50 production-shaped Bun server engineering tasks for evaluating AI coding agents.
+
+    Slug: tinycomputerai/bun-server-bench
+    Latest digest: sha256:fa582e2f208b5e8855f71b3f51d5cca140643e52e1b5aaedb37b6f003618f4ae
+    """
+    return _harbor_base(
+        package_name="tinycomputerai/bun-server-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def tmax_tmax_15k_harbor(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""15k compositional terminal-agent tasks: legacy 10k (self-contained) + v2 5k (intricate, multimodal fixtures). Programmatic verifier per task.
+
+    Slug: tmax/TMax-15K-Harbor
+    Latest digest: sha256:5c6ede990b3d0746fd2ea43ce154dbda23fda120a5ee3f2b0bc33a8d492fb329
+    """
+    return _harbor_base(
+        package_name="tmax/TMax-15K-Harbor",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def tmax_tmax_15k_harbor_trial(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Trial subset (12 tasks) of TMax-15K-Harbor: compositional terminal-agent tasks (legacy + v2 intricate w/ multimodal fixtures).
+
+    Slug: tmax/TMax-15K-Harbor-trial
+    Latest digest: sha256:bbec452ed3b5064cb8400d9f7b6c3a6e2bda657d1d2506be19dec3b5895ef37f
+    """
+    return _harbor_base(
+        package_name="tmax/TMax-15K-Harbor-trial",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3212,68 +3212,6 @@ def tinycomputerai_bun_server_bench(
 
 
 @task
-def tmax_tmax_15k_harbor(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""15k compositional terminal-agent tasks: legacy 10k (self-contained) + v2 5k (intricate, multimodal fixtures). Programmatic verifier per task.
-
-    Slug: tmax/TMax-15K-Harbor
-    Latest digest: sha256:5c6ede990b3d0746fd2ea43ce154dbda23fda120a5ee3f2b0bc33a8d492fb329
-    """
-    return _harbor_base(
-        package_name="tmax/TMax-15K-Harbor",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def tmax_tmax_15k_harbor_trial(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Trial subset (12 tasks) of TMax-15K-Harbor: compositional terminal-agent tasks (legacy + v2 intricate w/ multimodal fixtures).
-
-    Slug: tmax/TMax-15K-Harbor-trial
-    Latest digest: sha256:bbec452ed3b5064cb8400d9f7b6c3a6e2bda657d1d2506be19dec3b5895ef37f
-    """
-    return _harbor_base(
-        package_name="tmax/TMax-15K-Harbor-trial",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def usaco(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
islo-labs/reward-hack-bench
islo-labs/reward-hack-bench-control
tinycomputerai/bun-server-bench
tmax/TMax-15K-Harbor
tmax/TMax-15K-Harbor-trial
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks