### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/.agents/skills/nightly-pr-triage/SKILL.md
+++ b/.agents/skills/nightly-pr-triage/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: nightly-pr-triage
+description: Triage the nightly auto-update PR for the Harbor registry — fill in categories, title, repo, arxiv on newly-stubbed `docs/overrides.yml` entries so CI passes and the docs/AISI evals browser surface the dataset with proper branding.
+---
+
+# Nightly PR triage
+
+A scheduled GitHub Action (`.github/workflows/update-registry.yml`) runs every night, scrapes `hub.harborframework.com/datasets`, regenerates `src/inspect_harbor/_tasks.py` and `docs/registry-listing.yml`, and opens a PR titled `fix: update Harbor registry tasks` on the `update-harbor-tasks` branch. When new datasets appeared upstream, the bot auto-stubs them in `docs/overrides.yml` with `categories: []`. A human (you) needs to fill in real values before merge — `scripts/validate_overrides.py` runs in CI and blocks the merge on empty stubs.
+
+## Steps
+
+### 1. Find and check out the PR
+
+```bash
+gh pr list --repo meridianlabs-ai/inspect_harbor --search "update Harbor registry tasks" --state open
+```
+
+Check out cleanly — the bot force-pushes to `update-harbor-tasks` so a stale local copy will fail to fast-forward. Always reset first:
+
+```bash
+git switch main
+git pull --ff-only
+git branch -D update-harbor-tasks 2>/dev/null || true
+gh pr checkout <pr-number> --repo meridianlabs-ai/inspect_harbor
+```
+
+### 2. Identify newly-stubbed slugs
+
+The PR description lists them under "Action required: fill in categories for new datasets". Or pull from the diff directly:
+
+```bash
+git diff main..HEAD docs/overrides.yml | grep -B1 "categories: \[\]"
+```
+
+Each newly-stubbed entry looks like:
+
+```yaml
+org/name:
+  categories: []
+```
+
+### 3. Triage each stub: keep, exclude, or dedupe
+
+Not every auto-stubbed slug is a real benchmark worth listing. Before researching, decide for each stub whether it should be **kept** (→ research + fill, the common case), **excluded** (junk), or **deduped** (a copy of one we already list). Excluded/deduped slugs go in `docs/exclude.yml` instead of getting `categories` filled in.
+
+> The live scrape in step 6 (`validate_overrides.py`) often surfaces *more* new slugs than the PR description lists — datasets land on the hub after the nightly bot ran. Triage those the same way. Run validate early to see the full set.
+
+**Exclude experimental / personal junk.** People push half-finished or personal tasks to the hub that aren't published benchmarks. Tells:
+- Slug looks like a working file, not a release: `task1_v3_1_...`, `..._train_patched` / `..._eval_patched`, version/scratch suffixes (`-v1`, `-rolling`).
+- `desc` reads like an internal dev note, e.g. `"Patched verifier rebuild: reworked Modal capability-contract checks ... Tasks identical except tests/verify.py."`
+- Tiny task count (a handful of samples) with a generic name.
+- The org is an **individual**, not a project/company. Check it:
+  ```bash
+  gh api users/<org> -q '.type + " | " + (.name // "") + " | repos=" + (.public_repos|tostring)'
+  ```
+  `type=User` (a person) with no matching benchmark repo is a strong exclude signal; `type=Organization` (or a User whose repo *is* the canonical benchmark) is a keep signal. A slug whose org doesn't resolve at all (`404`) and reads like a dev artifact is junk.
+
+When in doubt about whether something is a real benchmark vs. junk, ask the user before excluding.
+
+**Dedupe copies published under multiple orgs.** The same benchmark sometimes appears under several org slugs (verbatim re-uploads). Keep the copy from the **most credible / original author** — the benchmark's actual authors, or the org that owns the upstream GitHub repo — and exclude the rest. Confirm they're really the same before dropping one:
+```bash
+uv run python -c "
+from inspect_harbor import <func_a>, <func_b>
+a, b = <func_a>().dataset, <func_b>().dataset
+print('counts:', len(a), len(b))
+print('inputs identical:', sorted(s.input for s in a) == sorted(s.input for s in b))
+"
+```
+Identical inputs (even if sample ids are renamed) ⇒ duplicate. Example: `xiaoboai/pawbench` is a verbatim copy of `agentscope-ai/pawbench` (same 150 inputs, renamed ids) — we keep `agentscope-ai` (the author org that owns the PawBench repo) and exclude `xiaoboai/pawbench`.
+
+**How to exclude.** Add a glob to `docs/exclude.yml` with a one-line comment saying *why*, prefer an org-wide glob (`ashantanu/*`, `vmax-modal/*`) for a junk account and an exact slug (`xiaoboai/pawbench`) for a single dedup. Then drop any stub the bot already added to `docs/overrides.yml` (pop it in the helper from step 5, or it'll linger as an orphan-warning). After regenerating, the slug disappears from `_tasks.py` and the listing. See the header of `docs/exclude.yml` for the existing patterns.
+
+### 4. Research each new dataset
+
+For each slug you're keeping, gather:
+
+| Field | Where to find it |
+|---|---|
+| `categories` | Required. Pick 1–2 from the vocabulary in `docs/overrides.yml`'s header (`Coding`, `Reasoning`, `Law`, `Multimodal`, …). See "Category picking" below. |
+| `title` | Canonical branding. Strongly suggested when the auto-derived form (just the slug suffix) is wrong-cased or non-obvious. |
+| `repo` | Canonical upstream GitHub URL. Almost always exists for benchmarks. |
+| `arxiv` | Paper URL if the benchmark has one. Many don't (especially newer ones). |
+| `desc` | **Read it for every slug you touch, but prefer Harbor's default.** Only override when the default is useless (a placeholder or bare restatement of the slug, e.g. `ivanleo/agent-search` ships `"Evaluation dataset for agent-search task."`), missing entirely, or extremely long. Length alone is usually fine — the listing table uses `desc_trunc`. See "Writing descriptions" below. |
+
+**Order of operations for research:**
+
+1. Check `docs/registry-listing.yml` for the slug — it carries Harbor's own `desc` field. That's often enough context for categorization, and the default `desc` is usually fine to publish as-is. **Read it, though** — it's surfaced on the registry listing and the AISI evals browser, so if it's a useless placeholder (or missing), plan to override it. See "Writing descriptions" below.
+2. Look at sibling entries in `docs/overrides.yml` (same `org/...` prefix, or same benchmark family) for naming/category patterns. Example: when `scale-ai/swe-atlas-rf` got auto-stubbed, sibling `scale-ai/swe-atlas-qna` and `scale-ai/swe-atlas-tw` already had `Coding` + `repo: https://github.com/scaleapi/SWE-Atlas` + `title: SWE-Atlas (QnA)` / `(Test Writing)` — same pattern applied directly.
+3. WebSearch (`<benchmark name> github`) when the brand or repo isn't obvious from the description. Skip this for self-evident names.
+4. Use `gNucleus AI` / `Harvey AI` style company-and-benchmark phrasing when both matter for findability.
+5. **When the domain is ambiguous, inspect a task input directly.** Load one sample and read its prompt — descriptions can mislead. Example: `gnucleus-ai/cad-bench`'s description says "100 parametric FreeCAD tasks" which sounds like pure CAD/Professional. The actual task prompt is "*Write a FreeCAD Python script to `answer.py` that reproduces the part described below*" — so it's code-gen into a CAD domain → `[Coding, Professional]`, not `[Professional]` alone. The one-liner:
+   ```bash
+   uv run python -c "from inspect_harbor import <func_name>; t = <func_name>(n_tasks=1); print(repr(t.dataset[0].input[:300]))"
+   ```
+
+**Category picking:**
+
+The canonical vocabulary lives at the top of `docs/overrides.yml`. Mirror it in `scripts/validate_overrides.py:CATEGORY_VOCAB` and inspect_ai's `docs/evals/sync.py:CATEGORY_VOCAB` (we don't own this — `inspect_ai` does — so don't invent new categories without coordinating with them).
+
+Common mappings:
+- Code-generation / agent benchmarks → `Coding`
+- Math, reasoning puzzles → `Reasoning` (use `Mathematics` only for explicit math content like AIME)
+- Legal, finance, medicine → `Law` / `Finance` / `Medicine` (often paired with `Professional`)
+- Vision/text-multimodal → `Multimodal`
+- Safety/jailbreak → `Safeguards`
+- Cybersecurity → `Cybersecurity`
+
+Use a secondary category when the benchmark spans clear domains (e.g. `MichaelY310/devopsgym` is `[Coding, Professional]` because DevOps is both code and a professional domain). Don't pile on for breadth — 1–2 strong categories beat 4 weak ones.
+
+**Title styling:**
+
+- Match the project's own canonical capitalization (`AIME`, `GAIA`, `USACO`, `BFCL`, `RExBench`, `SimpleQA`).
+- Use parens for splits: `KUMO (easy)`, `SWE-Lancer Diamond (Manager)`, `Reasoning Gym (hard)`.
+- Hyphens stay; spaces are for words: `SWE-bench Verified`, `DevOps-Gym`, `Terminal-Bench v2`.
+- Greek/Unicode is fine if it's the project's own form: `τ³-bench` for `sierra-research/tau3-bench`.
+- Skip the override when the leaf slug is already a clean display name (e.g. `runebench`, `vmax-tasks`).
+
+**Writing descriptions:**
+
+Read the `desc` for every slug you're filling in categories for — it's published verbatim on the registry listing and the AISI evals browser. But **prefer Harbor's default**: only write your own when the default is useless (a placeholder or bare restatement of the slug, like `"Evaluation dataset for agent-search task."`), absent, or extremely long. Length on its own isn't a reason — the table layout falls back to `desc_trunc`, so a long-but-informative default can stay.
+
+When you do rewrite, aim for one sentence that says **what the model is asked to do and in what domain** — concrete enough that a reader scanning the listing knows whether the benchmark is relevant. If the default is uninformative, inspect a task input (the one-liner above) to learn what the task really is, then write from that. Example: for `ivanleo/agent-search`, the task loads a docs SQLite DB and asks the agent to answer API questions by writing queries — so a fitting `desc` is `"Agent answers Gemini API questions by querying an indexed documentation database."` rather than the shipped placeholder.
+
+### 5. Apply the overrides
+
+Use the in-script helpers — they preserve the file's header comment and field order:
+
+```bash
+uv run python -c "
+import sys
+sys.path.insert(0, 'scripts')
+from generate_tasks import load_overrides, write_overrides_file
+overrides = load_overrides()
+overrides['org/name'] = {
+    'categories': ['Coding'],
+    'title': 'Pretty Name',
+    'repo': 'https://github.com/org/repo',
+    # 'arxiv': 'https://arxiv.org/abs/...',
+}
+write_overrides_file(overrides)
+"
+```
+
+### 6. Validate, regenerate, format, test
+
+```bash
+uv run python scripts/validate_overrides.py    # CI's gate; must report all valid
+uv run python scripts/generate_tasks.py        # regen _tasks.py + listing + per-dataset .qmd
+make check                                     # ruff (fixes _tasks.py docstring formatting)
+uv run pytest tests/ --no-header               # 167+ tests; should be 100% pass
+```
+
+### 7. Commit and push
+
+The bot's own commit on the branch already says `fix: update Harbor registry tasks`. Your commit can be the same or `fix: fill in categories for <new datasets>`. Push to `origin update-harbor-tasks`.
+
+### 8. After merge: publish the docs site
+
+The user merges the PR. Docs at https://meridianlabs-ai.github.io/inspect_harbor are not auto-published — the new datasets won't show up on the registry listing until someone re-renders + pushes `gh-pages`. Do it as soon as the merge lands so the public docs catch up:
+
+```bash
+git switch main
+git pull --ff-only
+cd docs
+PRE_COMMIT_ALLOW_NO_CONFIG=1 uv run quarto publish gh-pages --no-prompt
+```
+
+The `PRE_COMMIT_ALLOW_NO_CONFIG=1` env var is needed because the user has a global pre-commit hook that blocks the gh-pages worktree (which has no `.pre-commit-config.yaml`). Without it the publish renders successfully but the final commit fails silently and the remote `gh-pages` stays unchanged.
+
+GitHub Pages cache can take a few minutes after the push.
+
+## Gotchas
+
+### The scraper regex breaks when Harbor changes hub HTML
+
+Symptom: `scripts/generate_tasks.py` errors with `Scrape returned only 0 slug(s) (expected ≥ 50)`. Min-slug guard is doing its job — it'd otherwise orphan-drop every override.
+
+Cause: Harbor changes the hub's HTML format (e.g. moves from SSR `href="/datasets/..."` attrs to client-state JSON `\"href\":\"/datasets/...\"`).
+
+Fix: loosen the regex in `scrape_hub_slugs()` to match any `/datasets/<org>/<name>` occurrence, dropping the `href=` quote requirement. The character class `[A-Za-z0-9_.-]+` (no `/`) makes the match stop at the right boundary regardless of surrounding syntax.
+
+### `_tasks.py` docstring whitespace churn
+
+Regenerating sometimes produces a `_tasks.py` diff where continuation lines lose 4-space indents (e.g. on multi-line descriptions like `rexbench`). This is pre-existing — `make check` (which runs `ruff format`) re-applies the indent. Don't try to fix this in the template; just run `make check` and commit the result.
+
+### Category vocabulary is owned by inspect_ai
+
+`inspect_ai/docs/evals/sync.py:CATEGORY_VOCAB` is the source of truth. We mirror it in `scripts/validate_overrides.py:CATEGORY_VOCAB`. If you want to add a new category (e.g. `Gaming`, `DevOps`), propose it upstream in `inspect_ai` first — `sync_harbor.py` rejects unknown categories.
+
+## Reference files
+
+- `docs/overrides.yml` — the hand-maintained metadata, keyed by `org/name` slug. Header has full field documentation.
+- `docs/registry-listing.yml` — auto-generated machine-readable listing. Has `desc` (full) and `desc_trunc` (table-friendly).
+- `scripts/generate_tasks.py` — scrape + decorate + emit. Run after edits.
+- `scripts/validate_overrides.py` — CI gate. Run before push.
+- `scripts/_templates.py` — generated-file templates. Don't edit per-PR.
+- `docs/exclude.yml` — slug patterns to skip during scraping (e.g. `openthoughts/*`).
+- `.github/workflows/update-registry.yml` — the cron job that opens these PRs.

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -632,6 +632,9 @@ openai/swe-lancer-diamond-manager:
   desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.'
   title: SWE-Lancer Diamond (Manager)
 
+orca-bench/ORCA-bench:
+  categories: []
+
 orinlabs/horizon-public:
   categories:
   - Assistants
@@ -828,6 +831,9 @@ swe-bench/swe-smith:
   repo: https://github.com/SWE-bench/SWE-smith
   desc: 'SWE-smith: NeurIPS 2025 toolkit for synthesizing unlimited SWE-bench-style task instances from any Python repository, plus released task instances and agent trajectories.'
   title: SWE-smith
+
+swe-rebench/swe-rebench-leaderboard:
+  categories: []
 
 swt-bench/swt-bench-verified:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -436,6 +436,12 @@ grandsmile/unicode:
   desc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.'
   title: UniCode
 
+harbor-index/harbor-index-1.0:
+  categories:
+  - Assistants
+  - Reasoning
+  title: Harbor Index 1.0
+
 harveyai/lab:
   categories:
   - Law
@@ -633,7 +639,12 @@ openai/swe-lancer-diamond-manager:
   title: SWE-Lancer Diamond (Manager)
 
 orca-bench/ORCA-bench:
-  categories: []
+  categories:
+  - Coding
+  - Professional
+  title: ORCA-bench
+  repo: https://orca-bench.github.io
+  desc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
 
 orinlabs/horizon-public:
   categories:
@@ -833,7 +844,11 @@ swe-bench/swe-smith:
   title: SWE-smith
 
 swe-rebench/swe-rebench-leaderboard:
-  categories: []
+  categories:
+  - Coding
+  title: SWE-rebench Leaderboard
+  arxiv: https://arxiv.org/abs/2505.20411
+  repo: https://huggingface.co/datasets/nebius/SWE-rebench-leaderboard
 
 swt-bench/swt-bench-verified:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -687,6 +687,13 @@
   categories:
   - Coding
   - Professional
+- title: orca-bench/ORCA-bench
+  path: registry/orca_bench_orca_bench.html
+  desc: An agent benchmark for root cause analysis.
+  desc_trunc: An agent benchmark for root cause analysis.
+  task_function: orca_bench_orca_bench
+  samples: 1000
+  version: latest
 - title: orinlabs/horizon-public
   path: registry/orinlabs_horizon_public.html
   desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'
@@ -907,6 +914,13 @@
   version: latest
   categories:
   - Coding
+- title: swe-rebench/swe-rebench-leaderboard
+  path: registry/swe_rebench_swe_rebench_leaderboard.html
+  desc: 'SWE-rebench leaderboard: 860 curated Python SWE tasks from Nebius AI R&D. All instances have pre-built Docker images. Continuously updated monthly splits.'
+  desc_trunc: 'SWE-rebench leaderboard: 860 curated Python SWE tasks from Nebius AI R&D. All instances have pre-bu…'
+  task_function: swe_rebench_swe_rebench_leaderboard
+  samples: 860
+  version: latest
 - title: swt-bench/swt-bench-verified
   path: registry/swt_bench_verified.html
   desc: 'SWT-Bench Verified: human-validated subset of SWT-Bench evaluating LLMs on generating reproducing unit tests for real GitHub issues — tests must fail on buggy code and pass after the fix.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -457,6 +457,16 @@
   version: latest
   categories:
   - Coding
+- title: harbor-index/harbor-index-1.0
+  path: registry/harbor_index_harbor_index_1_0.html
+  desc: Harbor Index is an 82-task benchmark for agentic evaluation. It was distilled from more than 6,000 candidate tasks through repeated model runs, automated broken-task identification, human audits, and reward hacking supervision.
+  desc_trunc: Harbor Index is an 82-task benchmark for agentic evaluation. It was distilled from more than 6,000…
+  task_function: harbor_index_harbor_index_1_0
+  samples: 82
+  version: latest
+  categories:
+  - Assistants
+  - Reasoning
 - title: harveyai/lab
   path: registry/harveyai_lab.html
   desc: Harvey LAB - open-source benchmark for evaluating agents on real legal work.
@@ -689,11 +699,14 @@
   - Professional
 - title: orca-bench/ORCA-bench
   path: registry/orca_bench_orca_bench.html
-  desc: An agent benchmark for root cause analysis.
-  desc_trunc: An agent benchmark for root cause analysis.
+  desc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
+  desc_trunc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing me…
   task_function: orca_bench_orca_bench
   samples: 1000
   version: latest
+  categories:
+  - Coding
+  - Professional
 - title: orinlabs/horizon-public
   path: registry/orinlabs_horizon_public.html
   desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'
@@ -921,6 +934,8 @@
   task_function: swe_rebench_swe_rebench_leaderboard
   samples: 860
   version: latest
+  categories:
+  - Coding
 - title: swt-bench/swt-bench-verified
   path: registry/swt_bench_verified.html
   desc: 'SWT-Bench Verified: human-validated subset of SWT-Bench evaluating LLMs on generating reproducing unit tests for real GitHub issues — tests must fail on buggy code and pass after the fix.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -27,7 +27,7 @@ def litecoder_rl(
     r"""LiteCoder: terminal-based RL training environments spanning developer workflows, scientific/numerical computing, and games.
 
     Slug: LiteCoder/LiteCoder-rl
-    Latest digest: sha256:24d9797435e0cb765e18d46dacf72344d32e2f804f75682d365d68a5f3d4dc6a
+    Latest digest: sha256:f94f00b167519ae0d96efc990e383ce1793f5e707374165735bc512879878913
     """
     return _harbor_base(
         package_name="LiteCoder/LiteCoder-rl",
@@ -2214,6 +2214,37 @@ def openai_swe_lancer_diamond_manager(
 
 
 @task
+def orca_bench_orca_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""An agent benchmark for root cause analysis
+
+    Slug: orca-bench/ORCA-bench
+    Latest digest: sha256:fcd966f953a9fffd5b852767eee86ece9673d4e66b68aa9081700ba502c2adc6
+    """
+    return _harbor_base(
+        package_name="orca-bench/ORCA-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def orinlabs_horizon_public(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2920,6 +2951,37 @@ def swe_bench_swe_smith(
     """
     return _harbor_base(
         package_name="swe-bench/swe-smith",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def swe_rebench_swe_rebench_leaderboard(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""SWE-rebench leaderboard: 860 curated Python SWE tasks from Nebius AI R&D. All instances have pre-built Docker images. Continuously updated monthly splits.
+
+    Slug: swe-rebench/swe-rebench-leaderboard
+    Latest digest: sha256:ebe7444e313a0d8db94fa541139826eaebe2b0abcd4900c6f73e750494910dca
+    """
+    return _harbor_base(
+        package_name="swe-rebench/swe-rebench-leaderboard",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1470,6 +1470,37 @@ def grandsmile_unicode(
 
 
 @task
+def harbor_index_harbor_index_1_0(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Harbor Index is an 82-task benchmark for agentic evaluation. It was distilled from more than 6,000 candidate tasks through repeated model runs, automated broken-task identification, human audits, and reward hacking supervision.
+
+    Slug: harbor-index/harbor-index-1.0
+    Latest digest: sha256:9d4514cb93f6fafd9cf8ff352c784495ab675176c7f09671db523bd19b663584
+    """
+    return _harbor_base(
+        package_name="harbor-index/harbor-index-1.0",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def harveyai_lab(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2225,7 +2256,7 @@ def orca_bench_orca_bench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""An agent benchmark for root cause analysis
+    r"""Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
 
     Slug: orca-bench/ORCA-bench
     Latest digest: sha256:fcd966f953a9fffd5b852767eee86ece9673d4e66b68aa9081700ba502c2adc6


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
orca-bench/ORCA-bench
swe-rebench/swe-rebench-leaderboard
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks