### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -961,6 +961,9 @@ webgen-bench/webgen-bench:
   function_name: webgen_bench
   title: WebGen-Bench
 
+xlang-ai/osworld-verified:
+  categories: []
+
 xlang/ds-1000:
   categories:
   - Coding

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -962,7 +962,12 @@ webgen-bench/webgen-bench:
   title: WebGen-Bench
 
 xlang-ai/osworld-verified:
-  categories: []
+  categories:
+  - Assistants
+  - Multimodal
+  title: OSWorld-Verified
+  repo: https://github.com/xlang-ai/OSWorld
+  arxiv: https://arxiv.org/abs/2404.07972
 
 xlang/ds-1000:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -1069,6 +1069,13 @@
   version: latest
   categories:
   - Coding
+- title: xlang-ai/osworld-verified
+  path: registry/xlang_ai_osworld_verified.html
+  desc: 'OSWorld-Verified Harbor adaptation: 361 Ubuntu desktop-control tasks from OSWorld, excluding the 8 Google Drive/login credential-backed tasks.'
+  desc_trunc: 'OSWorld-Verified Harbor adaptation: 361 Ubuntu desktop-control tasks from OSWorld, excluding the 8…'
+  task_function: xlang_ai_osworld_verified
+  samples: 361
+  version: latest
 - title: yanagiorigami/frontier-cs
   path: registry/yanagiorigami_frontier_cs.html
   desc: 'Frontier-CS competitive programming benchmark: 172 open-ended algorithmic problems with partial scoring via go-judge.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -1076,6 +1076,9 @@
   task_function: xlang_ai_osworld_verified
   samples: 361
   version: latest
+  categories:
+  - Assistants
+  - Multimodal
 - title: yanagiorigami/frontier-cs
   path: registry/yanagiorigami_frontier_cs.html
   desc: 'Frontier-CS competitive programming benchmark: 172 open-ended algorithmic problems with partial scoring via go-judge.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3460,6 +3460,37 @@ def xlang_ds_1000(
 
 
 @task
+def xlang_ai_osworld_verified(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""OSWorld-Verified Harbor adaptation: 361 Ubuntu desktop-control tasks from OSWorld, excluding the 8 Google Drive/login credential-backed tasks.
+
+    Slug: xlang-ai/osworld-verified
+    Latest digest: sha256:1402d7ce0c95876f51e3e532a4a4663b1d535db6a3afc22815e9272cef822a7f
+    """
+    return _harbor_base(
+        package_name="xlang-ai/osworld-verified",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def yanagiorigami_frontier_cs(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
xlang-ai/osworld-verified
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks