### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -808,7 +808,11 @@ sldbench/sldbench:
   title: SLDBench
 
 snorkel-ai/senior-swe-bench-v2026.06:
-  categories: []
+  categories:
+  - Coding
+  title: Senior SWE-Bench (v2026.06)
+  repo: https://github.com/snorkel-ai/senior-swe-bench-v2026.06
+  desc: 'Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).'
 
 stanford/medagentbench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -807,6 +807,9 @@ sldbench/sldbench:
   function_name: sldbench
   title: SLDBench
 
+snorkel-ai/senior-swe-bench-v2026.06:
+  categories: []
+
 stanford/medagentbench:
   categories:
   - Professional

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -889,6 +889,13 @@
   - Science
   - Reasoning
   - Mathematics
+- title: snorkel-ai/senior-swe-bench-v2026.06
+  path: registry/snorkel_ai_senior_swe_bench_v2026_06.html
+  desc: Senior SWE-Bench (v2026.06) public dataset.
+  desc_trunc: Senior SWE-Bench (v2026.06) public dataset.
+  task_function: snorkel_ai_senior_swe_bench_v2026_06
+  samples: 50
+  version: latest
 - title: stanford/medagentbench
   path: registry/stanford_medagentbench.html
   desc: 'MedAgentBench: clinically-relevant tasks across 10 categories in a FHIR-compliant virtual EHR, benchmarking LLM agents on medical decision-making, planning, and execution.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -891,11 +891,13 @@
   - Mathematics
 - title: snorkel-ai/senior-swe-bench-v2026.06
   path: registry/snorkel_ai_senior_swe_bench_v2026_06.html
-  desc: Senior SWE-Bench (v2026.06) public dataset.
-  desc_trunc: Senior SWE-Bench (v2026.06) public dataset.
+  desc: 'Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).'
+  desc_trunc: 'Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production reposito…'
   task_function: snorkel_ai_senior_swe_bench_v2026_06
   samples: 50
   version: latest
+  categories:
+  - Coding
 - title: stanford/medagentbench
   path: registry/stanford_medagentbench.html
   desc: 'MedAgentBench: clinically-relevant tasks across 10 categories in a FHIR-compliant virtual EHR, benchmarking LLM agents on medical decision-making, planning, and execution.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2882,7 +2882,7 @@ def snorkel_ai_senior_swe_bench_v2026_06(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""Senior SWE-Bench (v2026.06) public dataset
+    r"""Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).
 
     Slug: snorkel-ai/senior-swe-bench-v2026.06
     Latest digest: sha256:58348968a3e850cfca1ea3f274384db4e771572ef0926206b9e5ed0851b5d453

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2871,6 +2871,37 @@ def sldbench(
 
 
 @task
+def snorkel_ai_senior_swe_bench_v2026_06(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Senior SWE-Bench (v2026.06) public dataset
+
+    Slug: snorkel-ai/senior-swe-bench-v2026.06
+    Latest digest: sha256:58348968a3e850cfca1ea3f274384db4e771572ef0926206b9e5ed0851b5d453
+    """
+    return _harbor_base(
+        package_name="snorkel-ai/senior-swe-bench-v2026.06",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def stanford_medagentbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
snorkel-ai/senior-swe-bench-v2026.06
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks