### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -25,3 +25,7 @@
 # paper, and no external footprint; all the user's repos are forks of other
 # projects. Includes a -trial upload-test subset. Not a published benchmark.
 - tmax/*
+# No public provenance: the GitHub user/org `svgap` doesn't exist, there is
+# no paper or repo, and the hub page carries no author metadata (8-sample
+# SystemVerilog reset-release micro-benchmark). Not a published benchmark.
+- svgap/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -441,6 +441,7 @@ harbor-index/harbor-index-1.0:
   - Assistants
   - Reasoning
   title: Harbor Index 1.0
+  function_name: harbor_index_1_0
 
 harveyai/lab:
   categories:
@@ -645,6 +646,7 @@ orca-bench/ORCA-bench:
   title: ORCA-bench
   repo: https://orca-bench.github.io
   desc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
+  function_name: orca_bench
 
 orinlabs/horizon-public:
   categories:
@@ -833,12 +835,6 @@ strongreject/strongreject:
   function_name: strongreject
   title: StrongREJECT
 
-svgap/svgap-reset-release:
-  categories:
-  - Coding
-  - Professional
-  title: SVGap (Reset-Release)
-
 swe-bench/swe-bench-verified:
   categories:
   - Coding
@@ -862,6 +858,7 @@ swe-rebench/swe-rebench-leaderboard:
   title: SWE-rebench Leaderboard
   arxiv: https://arxiv.org/abs/2505.20411
   repo: https://huggingface.co/datasets/nebius/SWE-rebench-leaderboard
+  function_name: swe_rebench_leaderboard
 
 swt-bench/swt-bench-verified:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -834,7 +834,10 @@ strongreject/strongreject:
   title: StrongREJECT
 
 svgap/svgap-reset-release:
-  categories: []
+  categories:
+  - Coding
+  - Professional
+  title: SVGap (Reset-Release)
 
 swe-bench/swe-bench-verified:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -833,6 +833,9 @@ strongreject/strongreject:
   function_name: strongreject
   title: StrongREJECT
 
+svgap/svgap-reset-release:
+  categories: []
+
 swe-bench/swe-bench-verified:
   categories:
   - Coding

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -925,6 +925,9 @@
   task_function: svgap_svgap_reset_release
   samples: 8
   version: latest
+  categories:
+  - Coding
+  - Professional
 - title: swe-bench/swe-bench-verified
   path: registry/swe_bench_verified.html
   desc: 'SWE-bench Verified: human-filtered subset of SWE-bench (collaboration with OpenAI) where human SWEs confirmed each real GitHub issue is solvable given the available repository context.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -918,6 +918,13 @@
   version: latest
   categories:
   - Safeguards
+- title: svgap/svgap-reset-release
+  path: registry/svgap_svgap_reset_release.html
+  desc: Can RTL agents pass simulation while violating reset-release structure? Eight SystemVerilog tasks measure the gap.
+  desc_trunc: Can RTL agents pass simulation while violating reset-release structure? Eight SystemVerilog tasks m…
+  task_function: svgap_svgap_reset_release
+  samples: 8
+  version: latest
 - title: swe-bench/swe-bench-verified
   path: registry/swe_bench_verified.html
   desc: 'SWE-bench Verified: human-filtered subset of SWE-bench (collaboration with OpenAI) where human SWEs confirmed each real GitHub issue is solvable given the available repository context.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -458,10 +458,10 @@
   categories:
   - Coding
 - title: harbor-index/harbor-index-1.0
-  path: registry/harbor_index_harbor_index_1_0.html
+  path: registry/harbor_index_1_0.html
   desc: Harbor Index is an 82-task benchmark for agentic evaluation. It was distilled from more than 6,000 candidate tasks through repeated model runs, automated broken-task identification, human audits, and reward hacking supervision.
   desc_trunc: Harbor Index is an 82-task benchmark for agentic evaluation. It was distilled from more than 6,000…
-  task_function: harbor_index_harbor_index_1_0
+  task_function: harbor_index_1_0
   samples: 82
   version: latest
   categories:
@@ -698,10 +698,10 @@
   - Coding
   - Professional
 - title: orca-bench/ORCA-bench
-  path: registry/orca_bench_orca_bench.html
+  path: registry/orca_bench.html
   desc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
   desc_trunc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing me…
-  task_function: orca_bench_orca_bench
+  task_function: orca_bench
   samples: 1000
   version: latest
   categories:
@@ -918,16 +918,6 @@
   version: latest
   categories:
   - Safeguards
-- title: svgap/svgap-reset-release
-  path: registry/svgap_svgap_reset_release.html
-  desc: Can RTL agents pass simulation while violating reset-release structure? Eight SystemVerilog tasks measure the gap.
-  desc_trunc: Can RTL agents pass simulation while violating reset-release structure? Eight SystemVerilog tasks m…
-  task_function: svgap_svgap_reset_release
-  samples: 8
-  version: latest
-  categories:
-  - Coding
-  - Professional
 - title: swe-bench/swe-bench-verified
   path: registry/swe_bench_verified.html
   desc: 'SWE-bench Verified: human-filtered subset of SWE-bench (collaboration with OpenAI) where human SWEs confirmed each real GitHub issue is solvable given the available repository context.'
@@ -947,10 +937,10 @@
   categories:
   - Coding
 - title: swe-rebench/swe-rebench-leaderboard
-  path: registry/swe_rebench_swe_rebench_leaderboard.html
+  path: registry/swe_rebench_leaderboard.html
   desc: 'SWE-rebench leaderboard: 860 curated Python SWE tasks from Nebius AI R&D. All instances have pre-built Docker images. Continuously updated monthly splits.'
   desc_trunc: 'SWE-rebench leaderboard: 860 curated Python SWE tasks from Nebius AI R&D. All instances have pre-bu…'
-  task_function: swe_rebench_swe_rebench_leaderboard
+  task_function: swe_rebench_leaderboard
   samples: 860
   version: latest
   categories:

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2964,6 +2964,37 @@ def strongreject(
 
 
 @task
+def svgap_svgap_reset_release(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Can RTL agents pass simulation while violating reset-release structure? Eight SystemVerilog tasks measure the gap.
+
+    Slug: svgap/svgap-reset-release
+    Latest digest: sha256:b8d75dc0bf83293875cd6e2dd82e81ff98738da83e35a0be0fc0fb330ca42eb2
+    """
+    return _harbor_base(
+        package_name="svgap/svgap-reset-release",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def swe_bench_verified(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1470,7 +1470,7 @@ def grandsmile_unicode(
 
 
 @task
-def harbor_index_harbor_index_1_0(
+def harbor_index_1_0(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -2245,7 +2245,7 @@ def openai_swe_lancer_diamond_manager(
 
 
 @task
-def orca_bench_orca_bench(
+def orca_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -2885,7 +2885,7 @@ def snorkel_ai_senior_swe_bench_v2026_06(
     r"""Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).
 
     Slug: snorkel-ai/senior-swe-bench-v2026.06
-    Latest digest: sha256:58348968a3e850cfca1ea3f274384db4e771572ef0926206b9e5ed0851b5d453
+    Latest digest: sha256:fc17418edc347f6bd9d952c100932930093ed919c404cbfe75712ebac7489b17
     """
     return _harbor_base(
         package_name="snorkel-ai/senior-swe-bench-v2026.06",
@@ -2964,37 +2964,6 @@ def strongreject(
 
 
 @task
-def svgap_svgap_reset_release(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Can RTL agents pass simulation while violating reset-release structure? Eight SystemVerilog tasks measure the gap.
-
-    Slug: svgap/svgap-reset-release
-    Latest digest: sha256:b8d75dc0bf83293875cd6e2dd82e81ff98738da83e35a0be0fc0fb330ca42eb2
-    """
-    return _harbor_base(
-        package_name="svgap/svgap-reset-release",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def swe_bench_verified(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3057,7 +3026,7 @@ def swe_bench_swe_smith(
 
 
 @task
-def swe_rebench_swe_rebench_leaderboard(
+def swe_rebench_leaderboard(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
svgap/svgap-reset-release
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks