### PR TITLE
ci: wire up the @auto agent (kickoff + autonomous loop)

### DIFF
--- a/.github/workflows/claude-auto.yml
+++ b/.github/workflows/claude-auto.yml
@@ -1,0 +1,65 @@
+# Auto agent (@auto) — thin stub over the shared Meridian autonomous-loop
+# workflows in meridianlabs-ai/agents. Independent of the dev agent (claude.yml)
+# and reviewer (claude-review.yml). Drives PRs carrying the `auto` label: fixes
+# CI failures and acts on the reviewer's summary comment.
+#
+# Requires the MARVIN_TOKEN org secret scoped to this repo.
+
+name: Claude Auto
+
+on:
+  # Phase 1: react to CI completing (so we can fix failures).
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+  # Phase 2/3: react to the reviewer's marked summary comment. issue_comment
+  # fires from the default branch, so this works on pristine-base forks too
+  # (unlike pull_request_review).
+  issue_comment:
+    types: [created]
+
+jobs:
+  # CI-failure -> fix. Only a *failed* CI run for a *same-repo* PR (same-repo
+  # excludes untrusted fork PRs). The reusable workflow does the authoritative
+  # gate (open PR + `auto` label + attempt cap).
+  ci-fix:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    uses: meridianlabs-ai/agents/.github/workflows/claude-auto.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+      ci_run_id: ${{ github.event.workflow_run.id }}
+
+  # Review -> fix / handoff. The marker is a cheap router (it's forgeable — only
+  # the reviewer posts it in practice); the reusable workflow does the authoritative
+  # gating (comment author == reviewer, same-repo, `auto` label, round cap), so
+  # the security boundary is there, not here.
+  review-fix:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != '' &&
+      contains(github.event.comment.body, '<!-- claude-review-summary -->')
+    uses: meridianlabs-ai/agents/.github/workflows/claude-auto-review.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      comment_author: ${{ github.event.comment.user.login }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,11 @@ jobs:
       contains(github.event.issue.title, '@claude') ||
       github.event.label.name == 'claude'
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    # MARVIN_TOKEN (machine-account PAT, org secret) so agent-opened PRs trigger
+    # CI and @review. Passed explicitly, not via `secrets: inherit`. Absent ->
+    # empty: the agent still runs, just with issue-triggered PR creation degraded.
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
     permissions:
       contents: write
       pull-requests: write
@@ -47,7 +52,8 @@ jobs:
         "Bash(git push:*)","Bash(git checkout:*)","Bash(git switch:*)",
         "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
         "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
-        "Bash(git remote:*)"]}}
+        "Bash(git remote:*)",
+        "Bash(git add:*)","Bash(git commit:*)","Bash(git config:*)"]}}
 
   # @auto kickoff — same reusable dev workflow, distinct trigger. An `@auto`
   # mention or `auto` label drives an issue/PR autonomously: the agent opens (or
@@ -74,8 +80,8 @@ jobs:
     with:
       trigger_phrase: "@auto"
       label_trigger: "auto"
-      # Same research tools as @claude above, plus git add/commit/config — the
-      # autonomous run commits its own fixes (the one-shot @claude flow does not).
+      # Same allow-list as the @claude job above (reusable default + the triage
+      # skill's research tools); kept in sync so the autonomous run has parity.
       settings: >-
         {"permissions":{"allow":["Read","Edit","Write",
         "WebSearch","WebFetch",

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,10 @@
 # Dev agent (@claude) — thin stub over the shared Meridian workflow in
 # meridianlabs-ai/agents. Mention @claude in an issue or PR comment (or add the
 # `claude` label to an issue) and Claude edits/pushes on a branch.
+#
+# The second job (@auto) reuses the SAME dev workflow but is the autonomous
+# kickoff: an `@auto` mention or `auto` label makes the agent open/adopt a PR,
+# carry the `auto` label onto it, and hand off to the loop in claude-auto.yml.
 
 name: Claude
 
@@ -44,3 +48,43 @@ jobs:
         "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
         "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
         "Bash(git remote:*)"]}}
+
+  # @auto kickoff — same reusable dev workflow, distinct trigger. An `@auto`
+  # mention or `auto` label drives an issue/PR autonomously: the agent opens (or
+  # adopts) a PR, propagates the `auto` label so the loop in claude-auto.yml
+  # engages, and runs to a human handoff. trigger_phrase/label_trigger are
+  # single-valued, so `auto` needs its own invocation. Needs MARVIN_TOKEN — the
+  # PR must be authored by the machine account to trigger CI and @review.
+  claude-auto:
+    if: |
+      contains(github.event.comment.body, '@auto') ||
+      contains(github.event.review.body, '@auto') ||
+      contains(github.event.issue.body, '@auto') ||
+      contains(github.event.issue.title, '@auto') ||
+      github.event.label.name == 'auto'
+    uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+    with:
+      trigger_phrase: "@auto"
+      label_trigger: "auto"
+      # Same research tools as @claude above, plus git add/commit/config — the
+      # autonomous run commits its own fixes (the one-shot @claude flow does not).
+      settings: >-
+        {"permissions":{"allow":["Read","Edit","Write",
+        "WebSearch","WebFetch",
+        "Bash(pytest:*)","Bash(ruff:*)","Bash(mypy:*)","Bash(pyright:*)","Bash(pip:*)",
+        "Bash(pip3:*)","Bash(uv:*)","Bash(python:*)","Bash(python3:*)",
+        "Bash(gh:*)","Bash(curl:*)",
+        "Bash(git fetch:*)","Bash(git merge:*)","Bash(git rebase:*)",
+        "Bash(git push:*)","Bash(git checkout:*)","Bash(git switch:*)",
+        "Bash(git branch:*)","Bash(git status:*)","Bash(git log:*)",
+        "Bash(git diff:*)","Bash(git show:*)","Bash(git rev-parse:*)",
+        "Bash(git remote:*)",
+        "Bash(git add:*)","Bash(git commit:*)","Bash(git config:*)"]}}


### PR DESCRIPTION
## What

Fully wires the `@auto` agent (inert before) and aligns the dev-agent stub with `inspect_flow` / the canonical stub.

### `@auto` wiring
1. **[claude.yml](../blob/add-auto-agent-workflow/.github/workflows/claude.yml)** — adds a `claude-auto` **kickoff** job alongside `@claude`. Same reusable dev workflow, gated on `@auto` mention / `auto` label with `trigger_phrase: "@auto"` + `label_trigger: "auto"`. Entry point: opens/adopts a PR, propagates the `auto` label, hands off.
2. **[claude-auto.yml](../blob/add-auto-agent-workflow/.github/workflows/claude-auto.yml)** — new stub over the shared autonomous-loop workflows for the later phases: **ci-fix** (failed `Build` run → fix) and **review-fix** (reviewer's `<!-- claude-review-summary -->` marker → address).

### Alignment with inspect_flow
3. `@claude` job now passes **`MARVIN_TOKEN`** (was missing) so agent-opened PRs trigger CI and `@review`.
4. Restored **`git add/commit/config`** to the `@claude` allow-list — the job intended "reusable default + research tools" but had drifted from an older default. Both jobs now share an identical allow-list (reusable default + the triage skill's WebSearch/WebFetch/curl).

## Verified against inspect_flow@main

| Item | Status |
|---|---|
| `@auto` kickoff job in `claude.yml` | ✅ match |
| `claude-auto.yml` (ci-fix + review-fix, `workflows: ["Build"]`) | ✅ match |
| `@claude` passes `MARVIN_TOKEN` | ✅ fixed |
| `@claude` allow-list incl. `git add/commit/config` | ✅ fixed |
| Research tools (WebSearch/curl) in settings | intentional inspect_harbor divergence (nightly triage skill) |
| `claude-review.yml` auto-review-on-open | left as-is by decision — inspect_harbor keeps `@review`-comment-only + `allowed_bots: claude[bot]` for the nightly bot PR; the `@auto` loop still engages because the kickoff posts `@review` |

## ⚠️ Manual checks before this works

1. **`MARVIN_TOKEN` org secret must be scoped to `inspect_harbor`** — couldn't verify (no `admin:org`). Without it the token resolves empty: `@claude` PR creation is degraded and `@auto` no-ops.
2. **Testing requires merge to `main` first** — GitHub runs `issue_comment` / `issues` / `workflow_run` handlers only from the default-branch copy. So `@auto` can't be exercised from this PR; merge, then create an `auto`-labeled test issue/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)