### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/.agents/skills/nightly-pr-triage/SKILL.md
+++ b/.agents/skills/nightly-pr-triage/SKILL.md
@@ -79,6 +79,7 @@ For each slug you're keeping, gather:
 | Field | Where to find it |
 |---|---|
 | `categories` | Required. Pick 1–2 from the vocabulary in `docs/overrides.yml`'s header (`Coding`, `Reasoning`, `Law`, `Multimodal`, …). See "Category picking" below. |
+| `function_name` | **Required whenever the auto-derived function name stutters** (org repeated in the name, e.g. `android_bench_android_bench`). See "Function-name dedup" below. Otherwise omit. |
 | `title` | Canonical branding. Strongly suggested when the auto-derived form (just the slug suffix) is wrong-cased or non-obvious. |
 | `repo` | Canonical upstream GitHub URL. Almost always exists for benchmarks. |
 | `arxiv` | Paper URL if the benchmark has one. Many don't (especially newer ones). |
@@ -116,6 +117,14 @@ Use a secondary category when the benchmark spans clear domains (e.g. `MichaelY3
 - Hyphens stay; spaces are for words: `SWE-bench Verified`, `DevOps-Gym`, `Terminal-Bench v2`.
 - Greek/Unicode is fine if it's the project's own form: `τ³-bench` for `sierra-research/tau3-bench`.
 - Skip the override when the leaf slug is already a clean display name (e.g. `runebench`, `vmax-tasks`).
+
+**Function-name dedup:**
+
+The generator derives the Python task function from the full slug (`org/name` → `org_name`), so a slug whose name repeats its org produces a stuttering identifier: `android-bench/android-bench` → `android_bench_android_bench`, `swe_bench/swe-bench-verified` → `swe_bench_swe_bench_verified`. **Whenever the auto-derived name contains this org/name duplication, always add a `function_name` override that collapses it** (`android_bench`, `swe_bench_verified`) — the function name is what users type (`inspect eval inspect_harbor/<function_name>`) and it names the generated docs page, so the stutter is pure noise. Rules:
+
+- Dedup only the repeated org prefix; keep the rest of the name intact (`swe_bench_verified`, not `verified`).
+- Before applying, check the deduped name doesn't collide with an existing function: `grep -n "^def <name>(" src/inspect_harbor/_tasks.py`. On a collision, keep the auto-derived name and flag it for the reviewer instead.
+- Regenerating in step 6 propagates the rename into `src/inspect_harbor/_tasks.py`, `docs/registry-listing.yml` (`task_function` + page path), and the per-benchmark `.qmd` page — never hand-edit those.
 
 **Writing descriptions:**
 

--- a/.claude/skills/nightly-pr-triage/SKILL.md
+++ b/.claude/skills/nightly-pr-triage/SKILL.md
@@ -79,6 +79,7 @@ For each slug you're keeping, gather:
 | Field | Where to find it |
 |---|---|
 | `categories` | Required. Pick 1–2 from the vocabulary in `docs/overrides.yml`'s header (`Coding`, `Reasoning`, `Law`, `Multimodal`, …). See "Category picking" below. |
+| `function_name` | **Required whenever the auto-derived function name stutters** (org repeated in the name, e.g. `android_bench_android_bench`). See "Function-name dedup" below. Otherwise omit. |
 | `title` | Canonical branding. Strongly suggested when the auto-derived form (just the slug suffix) is wrong-cased or non-obvious. |
 | `repo` | Canonical upstream GitHub URL. Almost always exists for benchmarks. |
 | `arxiv` | Paper URL if the benchmark has one. Many don't (especially newer ones). |
@@ -116,6 +117,14 @@ Use a secondary category when the benchmark spans clear domains (e.g. `MichaelY3
 - Hyphens stay; spaces are for words: `SWE-bench Verified`, `DevOps-Gym`, `Terminal-Bench v2`.
 - Greek/Unicode is fine if it's the project's own form: `τ³-bench` for `sierra-research/tau3-bench`.
 - Skip the override when the leaf slug is already a clean display name (e.g. `runebench`, `vmax-tasks`).
+
+**Function-name dedup:**
+
+The generator derives the Python task function from the full slug (`org/name` → `org_name`), so a slug whose name repeats its org produces a stuttering identifier: `android-bench/android-bench` → `android_bench_android_bench`, `swe_bench/swe-bench-verified` → `swe_bench_swe_bench_verified`. **Whenever the auto-derived name contains this org/name duplication, always add a `function_name` override that collapses it** (`android_bench`, `swe_bench_verified`) — the function name is what users type (`inspect eval inspect_harbor/<function_name>`) and it names the generated docs page, so the stutter is pure noise. Rules:
+
+- Dedup only the repeated org prefix; keep the rest of the name intact (`swe_bench_verified`, not `verified`).
+- Before applying, check the deduped name doesn't collide with an existing function: `grep -n "^def <name>(" src/inspect_harbor/_tasks.py`. On a collision, keep the auto-derived name and flag it for the reviewer instead.
+- Regenerating in step 6 propagates the rename into `src/inspect_harbor/_tasks.py`, `docs/registry-listing.yml` (`task_function` + page path), and the per-benchmark `.qmd` page — never hand-edit those.
 
 **Writing descriptions:**
 

--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -132,6 +132,8 @@ jobs:
           __STUBBED__
           ```
 
+          If any of these slugs produces a stuttering auto-derived task function name (org repeated in the name, e.g. `android-bench/android-bench` → `android_bench_android_bench`), follow the "Function-name dedup" instructions in step 4 of the skill and add a `function_name` override that collapses the duplication.
+
           When done, post a short summary comment (what you filled; what you left and why), then post `@review` as a separate comment.
           EOF
           )"

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -185,6 +185,9 @@ algotune/algotune:
   function_name: algotune
   title: AlgoTune
 
+android-bench/android-bench:
+  categories: []
+
 apple/mmau:
   categories:
   - Assistants
@@ -645,15 +648,6 @@ openai/swe-lancer-diamond-manager:
   repo: https://github.com/openai/SWELancer-Benchmark
   desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.'
   title: SWE-Lancer Diamond (Manager)
-
-orca-bench/ORCA-bench:
-  categories:
-  - Coding
-  - Professional
-  title: ORCA-bench
-  repo: https://orca-bench.github.io
-  desc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
-  function_name: orca_bench
 
 orinlabs/horizon-public:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -190,6 +190,7 @@ android-bench/android-bench:
   - Coding
   title: Android Bench
   repo: https://github.com/android-bench/android-bench
+  function_name: android_bench
 
 apple/mmau:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -186,7 +186,10 @@ algotune/algotune:
   title: AlgoTune
 
 android-bench/android-bench:
-  categories: []
+  categories:
+  - Coding
+  title: Android Bench
+  repo: https://github.com/android-bench/android-bench
 
 apple/mmau:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -167,6 +167,13 @@
   version: latest
   categories:
   - Coding
+- title: android-bench/android-bench
+  path: registry/android_bench_android_bench.html
+  desc: A dataset of 100 Android software engineering tasks derived from real-world repositories.
+  desc_trunc: A dataset of 100 Android software engineering tasks derived from real-world repositories.
+  task_function: android_bench_android_bench
+  samples: 100
+  version: latest
 - title: apple/mmau
   path: registry/apple_mmau.html
   desc: 'MMAU (Massive Multitask Agent Understanding): Apple''s holistic agent benchmark covering tool-use, DAG QA, data science/ML coding, contest programming, and mathematics.'
@@ -702,16 +709,6 @@
   desc_trunc: A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in…
   task_function: openai_swe_lancer_diamond_manager
   samples: 265
-  version: latest
-  categories:
-  - Coding
-  - Professional
-- title: orca-bench/ORCA-bench
-  path: registry/orca_bench.html
-  desc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
-  desc_trunc: Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing me…
-  task_function: orca_bench
-  samples: 1000
   version: latest
   categories:
   - Coding

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -174,6 +174,8 @@
   task_function: android_bench_android_bench
   samples: 100
   version: latest
+  categories:
+  - Coding
 - title: apple/mmau
   path: registry/apple_mmau.html
   desc: 'MMAU (Massive Multitask Agent Understanding): Apple''s holistic agent benchmark covering tool-use, DAG QA, data science/ML coding, contest programming, and mathematics.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -168,10 +168,10 @@
   categories:
   - Coding
 - title: android-bench/android-bench
-  path: registry/android_bench_android_bench.html
+  path: registry/android_bench.html
   desc: A dataset of 100 Android software engineering tasks derived from real-world repositories.
   desc_trunc: A dataset of 100 Android software engineering tasks derived from real-world repositories.
-  task_function: android_bench_android_bench
+  task_function: android_bench
   samples: 100
   version: latest
   categories:

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -540,7 +540,7 @@ def algotune(
 
 
 @task
-def android_bench_android_bench(
+def android_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -2605,8 +2605,8 @@ def rexbench(
     Adapter by Nicholas Edwards (nicholas.edwards@univie.ac.at), one of the original RExBench authors.
     Acknowledgements: We thank 2077 AI for generously funding API credits to support running parity experiments.
 
-    Slug: rexbench/rexbench
-    Latest digest: sha256:bc23e94793e8c74aceb8f6fdb3a268dc834b4699f71b1329db9222e83bb5ac4f
+        Slug: rexbench/rexbench
+        Latest digest: sha256:bc23e94793e8c74aceb8f6fdb3a268dc834b4699f71b1329db9222e83bb5ac4f
     """
     return _harbor_base(
         package_name="rexbench/rexbench",

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -540,6 +540,37 @@ def algotune(
 
 
 @task
+def android_bench_android_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""A dataset of 100 Android software engineering tasks derived from real-world repositories.
+
+    Slug: android-bench/android-bench
+    Latest digest: sha256:6f1cc5002e53265c243f3d08940faea1d38c05a0e22a91a841ac9937aeb3416c
+    """
+    return _harbor_base(
+        package_name="android-bench/android-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def apple_mmau(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2276,37 +2307,6 @@ def openai_swe_lancer_diamond_manager(
 
 
 @task
-def orca_bench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Agents perform on-call root cause analysis on a live instrumented microservice system, analyzing metrics, logs, traces, and source code to identify the root cause of production incidents.
-
-    Slug: orca-bench/ORCA-bench
-    Latest digest: sha256:fcd966f953a9fffd5b852767eee86ece9673d4e66b68aa9081700ba502c2adc6
-    """
-    return _harbor_base(
-        package_name="orca-bench/ORCA-bench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def orinlabs_horizon_public(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2916,7 +2916,7 @@ def snorkel_ai_senior_swe_bench_v2026_06(
     r"""Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).
 
     Slug: snorkel-ai/senior-swe-bench-v2026.06
-    Latest digest: sha256:fc17418edc347f6bd9d952c100932930093ed919c404cbfe75712ebac7489b17
+    Latest digest: sha256:fdfbce8953be56c009a773140adccc53e24f92d8682e1bf8b2f785506a51f15d
     """
     return _harbor_base(
         package_name="snorkel-ai/senior-swe-bench-v2026.06",


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
android-bench/android-bench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks