### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -58,7 +58,11 @@
 #   featured:      boolean                                      (optional)
 
 Enterprise-Bench/l1-l2-bench:
-  categories: []
+  categories:
+  - Assistants
+  - Professional
+  title: Enterprise-Bench (L1-L2)
+  desc: 'Enterprise-Bench (L1-L2): DevRev''s enterprise agent benchmark — answering L1/L2 support-tier questions (ticket SLAs, triage, customer-account data) over fragmented enterprise systems.'
 
 LiteCoder/LiteCoder-rl:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -57,6 +57,9 @@
 #   desc:          override the auto-derived description        (optional)
 #   featured:      boolean                                      (optional)
 
+Enterprise-Bench/l1-l2-bench:
+  categories: []
+
 LiteCoder/LiteCoder-rl:
   categories:
   - Coding

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -6,6 +6,13 @@
 #   PackageDatasetClient.get_dataset_metadata for each slug.
 # Categories: docs/overrides.yml (hand-maintained; see file header).
 
+- title: Enterprise-Bench/l1-l2-bench
+  path: registry/enterprise_bench_l1_l2_bench.html
+  desc: Enterprise Agent Benchmark.
+  desc_trunc: Enterprise Agent Benchmark.
+  task_function: enterprise_bench_l1_l2_bench
+  samples: 14
+  version: latest
 - title: LiteCoder/LiteCoder-rl
   path: registry/litecoder_rl.html
   desc: 'LiteCoder: terminal-based RL training environments spanning developer workflows, scientific/numerical computing, and games.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -8,11 +8,14 @@
 
 - title: Enterprise-Bench/l1-l2-bench
   path: registry/enterprise_bench_l1_l2_bench.html
-  desc: Enterprise Agent Benchmark.
-  desc_trunc: Enterprise Agent Benchmark.
+  desc: 'Enterprise-Bench (L1-L2): DevRev''s enterprise agent benchmark — answering L1/L2 support-tier questions (ticket SLAs, triage, customer-account data) over fragmented enterprise systems.'
+  desc_trunc: 'Enterprise-Bench (L1-L2): DevRev''s enterprise agent benchmark — answering L1/L2 support-tier questi…'
   task_function: enterprise_bench_l1_l2_bench
   samples: 14
   version: latest
+  categories:
+  - Assistants
+  - Professional
 - title: LiteCoder/LiteCoder-rl
   path: registry/litecoder_rl.html
   desc: 'LiteCoder: terminal-based RL training environments spanning developer workflows, scientific/numerical computing, and games.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -24,7 +24,7 @@ def enterprise_bench_l1_l2_bench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""Enterprise Agent Benchmark
+    r"""Enterprise-Bench (L1-L2): DevRev's enterprise agent benchmark — answering L1/L2 support-tier questions (ticket SLAs, triage, customer-account data) over fragmented enterprise systems.
 
     Slug: Enterprise-Bench/l1-l2-bench
     Latest digest: sha256:2e4e4cc423c5636d6d767e30ceb3f831bb0c83178f0387f0452077b36f49ee93

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -13,6 +13,37 @@ from inspect_harbor._harbor.task import harbor as _harbor_base
 
 
 @task
+def enterprise_bench_l1_l2_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Enterprise Agent Benchmark
+
+    Slug: Enterprise-Bench/l1-l2-bench
+    Latest digest: sha256:2e4e4cc423c5636d6d767e30ceb3f831bb0c83178f0387f0452077b36f49ee93
+    """
+    return _harbor_base(
+        package_name="Enterprise-Bench/l1-l2-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def litecoder_rl(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2605,8 +2636,8 @@ def rexbench(
     Adapter by Nicholas Edwards (nicholas.edwards@univie.ac.at), one of the original RExBench authors.
     Acknowledgements: We thank 2077 AI for generously funding API credits to support running parity experiments.
 
-        Slug: rexbench/rexbench
-        Latest digest: sha256:bc23e94793e8c74aceb8f6fdb3a268dc834b4699f71b1329db9222e83bb5ac4f
+    Slug: rexbench/rexbench
+    Latest digest: sha256:bc23e94793e8c74aceb8f6fdb3a268dc834b4699f71b1329db9222e83bb5ac4f
     """
     return _harbor_base(
         package_name="rexbench/rexbench",


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
Enterprise-Bench/l1-l2-bench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks