### PR TITLE
ci: allow hotfix releases via workflow_dispatch target-branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      target-branch:
+        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
+        type: string
+        default: main
 
 jobs:
   release-please:
@@ -13,6 +19,7 @@ jobs:
     uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
     with:
       approvers: "alexandraabbas jjallaire dragonstyle"
+      target-branch: ${{ inputs.target-branch }}
     secrets: inherit
 
   # Publish stays in-repo (PyPI trusted publishing can't run from a cross-repo


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger with a `target-branch` input and passes it through to the reusable `release-please-python.yml@v1` workflow. This is backward compatible: on `push` the input is empty, so the reusable workflow falls back to its default branch and normal releases are unchanged. On manual dispatch it enables cutting releases from a maintenance/hotfix branch (e.g. `hotfix/1.4.x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)