### PR TITLE
ci: drop redundant target-branch dispatch input (single-control hotfix)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      target-branch:
-        description: "Maintenance branch to release from (e.g. hotfix/1.4.x). Leave as main for a normal release."
-        type: string
-        default: main
 
 jobs:
   release-please:
@@ -19,7 +14,6 @@ jobs:
     uses: meridianlabs-ai/actions/.github/workflows/release-please-python.yml@v1
     with:
       approvers: "alexandraabbas jjallaire dragonstyle"
-      target-branch: ${{ inputs.target-branch }}
     secrets: inherit
 
   # Publish stays in-repo (PyPI trusted publishing can't run from a cross-repo


### PR DESCRIPTION
The reusable workflow (`release-please-python.yml@v1`) now derives `target-branch` from the dispatched branch (`github.ref_name`), so this caller's own `target-branch` input is redundant — and its `default: main` would actually override the new behavior.

Removing it makes the "Use workflow from" branch selector the sole control (mirrors meridianlabs-ai/actions#66). Normal push-to-main releases are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)