### PR TITLE
docs: add minimal AGENTS.md with PR-title and release guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+## Pull Requests
+
+- Title PRs as Conventional Commits (`<type>: <description>`)—we squash-merge, so the PR title becomes the commit message that drives releases; `pr-title-lint` enforces it
+- `feat:`/`fix:` are for user-facing changes only: they headline the release notes and bump the version. `perf:`/`revert:` also appear in the notes (no bump); `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`, `style:` are hidden
+- Body lines starting with `<type>:` are parsed as extra changelog entries—don't begin description lines with a conventional-commit prefix unless that's intended
+- Never edit `CHANGELOG.md`, version numbers, or `.release-please-manifest.json`—Release Please owns them
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Coding agents read AGENTS.md/CLAUDE.md automatically but not CONTRIBUTING.md, so this inlines the PR-title rules that drive releases (Conventional Commits, squash-merge, Release Please ownership). CLAUDE.md is a relative symlink to AGENTS.md per the org pattern (inspect_scout/inspect_petri/petri_bloom); mirrors inspect_scout#533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)