### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -38,3 +38,18 @@
 # no task-aw repo exists on GitHub and no paper or external footprint. Not a
 # published benchmark.
 - abhishek203/*
+# Timestamped terminal-bench CI/upload-test scratch orgs (e.g.
+# tbench-up4-a-up4_1784108341_146593/up4-dataset); dev artifacts, not
+# benchmarks. The underscore before the slash keeps this from matching a
+# hypothetical legitimate tbench-* org.
+- tbench-*_*/*
+# Re-upload of Harvey LAB by an individual (User, not org) from a fork of
+# harveyai/harvey-labs: all 1,251 task ids of the canonical harveyai/lab are
+# a strict subset of its 1,760 (extra "scenario" variants, non-canonical
+# rewardkit/OpenRouter grading). Keep the author org's harveyai/lab.
+- punitarani/harvey-labs
+# Verbatim duplicate of userbench/UserBench (identical 1,520 inputs AND
+# sample ids) under the project's superseded name — the UserBench desc says
+# "Formerly developed as SWESimBench v2". Whether userbench/UserBench itself
+# is kept is a separate (human) call; this stale-name copy goes regardless.
+- swesimbench/SWESimBench

--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -50,6 +50,6 @@
 - punitarani/harvey-labs
 # Verbatim duplicate of userbench/UserBench (identical 1,520 inputs AND
 # sample ids) under the project's superseded name — the UserBench desc says
-# "Formerly developed as SWESimBench v2". Whether userbench/UserBench itself
-# is kept is a separate (human) call; this stale-name copy goes regardless.
+# "Formerly developed as SWESimBench v2". userbench/UserBench is kept
+# (categorized in overrides.yml); this stale-name copy goes regardless.
 - swesimbench/SWESimBench

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -983,8 +983,18 @@ usaco/usaco:
   title: USACO
 
 userbench/UserBench:
-  categories: []
+  categories:
+  - Assistants
+  - Coding
   function_name: userbench
+  title: UserBench (SWE user simulation)
+
+userbench/UserBench-train400:
+  categories:
+  - Assistants
+  - Coding
+  function_name: userbench_train400
+  title: UserBench (SWE user simulation, train400)
 
 vals/financeagent:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -984,6 +984,7 @@ usaco/usaco:
 
 userbench/UserBench:
   categories: []
+  function_name: userbench
 
 vals/financeagent:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -183,6 +183,9 @@ aime/aime:
   function_name: aime
   title: AIME
 
+ale/rsi-post-training:
+  categories: []
+
 algotune/algotune:
   categories:
   - Coding
@@ -219,6 +222,9 @@ arcprize/arc-agi-2:
   desc: 'ARC-AGI-2: visual reasoning tasks testing general fluid intelligence — humans solve them easily but state-of-the-art models still struggle.'
   title: ARC-AGI-2
   featured: true
+
+atm-bench/atm-bench-hard-sgm:
+  categories: []
 
 benchflow/skillsbench:
   categories:
@@ -682,6 +688,9 @@ pgcodellm/rebench-v2-test:
   desc: 'SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.'
   title: SWE-rebench V2
 
+punitarani/harvey-labs:
+  categories: []
+
 qcircuitbench/qcircuitbench:
   categories:
   - Science
@@ -879,6 +888,9 @@ swe-rebench/swe-rebench-leaderboard:
   repo: https://huggingface.co/datasets/nebius/SWE-rebench-leaderboard
   function_name: swe_rebench_leaderboard
 
+swesimbench/SWESimBench:
+  categories: []
+
 swt-bench/swt-bench-verified:
   categories:
   - Coding
@@ -965,6 +977,9 @@ usaco/usaco:
   desc: 'USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.'
   function_name: usaco
   title: USACO
+
+userbench/UserBench:
+  categories: []
 
 vals/financeagent:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -184,7 +184,10 @@ aime/aime:
   title: AIME
 
 ale/rsi-post-training:
-  categories: []
+  categories:
+  - Coding
+  - Science
+  title: ALE RSI Post-Training
 
 algotune/algotune:
   categories:
@@ -224,7 +227,14 @@ arcprize/arc-agi-2:
   featured: true
 
 atm-bench/atm-bench-hard-sgm:
-  categories: []
+  categories:
+  - Assistants
+  - Reasoning
+  arxiv: https://arxiv.org/abs/2603.01990
+  repo: https://github.com/JingbiaoMei/ATM-Bench
+  desc: 'ATM-Bench-Hard (SGM): 31 hard long-term personalized memory questions answered from schema-guided memory (SGM) files distilled from ~4 years of a user''s images, videos, and emails.'
+  function_name: atm_bench_hard_sgm
+  title: ATM-Bench-Hard (SGM)
 
 benchflow/skillsbench:
   categories:
@@ -688,9 +698,6 @@ pgcodellm/rebench-v2-test:
   desc: 'SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.'
   title: SWE-rebench V2
 
-punitarani/harvey-labs:
-  categories: []
-
 qcircuitbench/qcircuitbench:
   categories:
   - Science
@@ -887,9 +894,6 @@ swe-rebench/swe-rebench-leaderboard:
   arxiv: https://arxiv.org/abs/2505.20411
   repo: https://huggingface.co/datasets/nebius/SWE-rebench-leaderboard
   function_name: swe_rebench_leaderboard
-
-swesimbench/SWESimBench:
-  categories: []
 
 swt-bench/swt-bench-verified:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -1090,11 +1090,24 @@
   - Coding
 - title: userbench/UserBench
   path: registry/userbench.html
-  desc: 'UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as SWESimBench v2.'
-  desc_trunc: 'UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as…'
+  desc: 'UserBench eval: 620 noprofile next-message tasks across 62 developers (exactly 10 shortest-history points per developer with ≥10 eval points).'
+  desc_trunc: 'UserBench eval: 620 noprofile next-message tasks across 62 developers (exactly 10 shortest-history…'
   task_function: userbench
-  samples: 1520
+  samples: 620
   version: latest
+  categories:
+  - Assistants
+  - Coding
+- title: userbench/UserBench-train400
+  path: registry/userbench_train400.html
+  desc: 'UserBench train400 twin: same 620 held tasks as UserBench@v2 plus leak-safe /sim/train/ with 400 human-turns (sqrt two-stage) per developer.'
+  desc_trunc: 'UserBench train400 twin: same 620 held tasks as UserBench@v2 plus leak-safe /sim/train/ with 400 hu…'
+  task_function: userbench_train400
+  samples: 620
+  version: latest
+  categories:
+  - Assistants
+  - Coding
 - title: vals/financeagent
   path: registry/vals_financeagent.html
   desc: 'Vals AI Finance Agent Benchmark: expert-validated finance questions across nine task categories (retrieval, market research, projections) with EDGAR/SEC search tools for evaluating financial agents.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -175,6 +175,9 @@
   task_function: ale_rsi_post_training
   samples: 5
   version: latest
+  categories:
+  - Coding
+  - Science
 - title: algotune/algotune
   path: registry/algotune.html
   desc: 'AlgoTune: NeurIPS 2025 benchmark of math/physics/CS problems where the model writes code that matches reference output but runs faster than existing implementations.'
@@ -216,12 +219,15 @@
   - Reasoning
   - Multimodal
 - title: atm-bench/atm-bench-hard-sgm
-  path: registry/atm_bench_atm_bench_hard_sgm.html
-  desc: ATM-Bench-Hard SGM Harbor tasks.
-  desc_trunc: ATM-Bench-Hard SGM Harbor tasks.
-  task_function: atm_bench_atm_bench_hard_sgm
+  path: registry/atm_bench_hard_sgm.html
+  desc: 'ATM-Bench-Hard (SGM): 31 hard long-term personalized memory questions answered from schema-guided memory (SGM) files distilled from ~4 years of a user''s images, videos, and emails.'
+  desc_trunc: 'ATM-Bench-Hard (SGM): 31 hard long-term personalized memory questions answered from schema-guided m…'
+  task_function: atm_bench_hard_sgm
   samples: 31
   version: latest
+  categories:
+  - Assistants
+  - Reasoning
 - title: benchflow/skillsbench
   path: registry/benchflow_skillsbench.html
   desc: 'SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folders of instructions, scripts, and resources) to complete specialized workflows spanning science, engineering, and professional domains.'
@@ -767,13 +773,6 @@
   version: latest
   categories:
   - Coding
-- title: punitarani/harvey-labs
-  path: registry/punitarani_harvey_labs.html
-  desc: 'Harvey Labs: 1,760 legal-drafting tasks (LAB) across 26 practice areas, graded with Harbor rewardkit (LLM-judge, OpenRouter default, 111,826 binary criteria).'
-  desc_trunc: 'Harvey Labs: 1,760 legal-drafting tasks (LAB) across 26 practice areas, graded with Harbor rewardki…'
-  task_function: punitarani_harvey_labs
-  samples: 1760
-  version: latest
 - title: qcircuitbench/qcircuitbench
   path: registry/qcircuitbench.html
   desc: 'QCircuitBench: large-scale benchmark for LLM-driven quantum-algorithm design, spanning oracle construction, algorithm design, and random circuits with automatic verification.'
@@ -994,13 +993,6 @@
   version: latest
   categories:
   - Coding
-- title: swesimbench/SWESimBench
-  path: registry/swesimbench_swesimbench.html
-  desc: 'SWESimBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks).'
-  desc_trunc: 'SWESimBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks).'
-  task_function: swesimbench_swesimbench
-  samples: 1520
-  version: latest
 - title: swt-bench/swt-bench-verified
   path: registry/swt_bench_verified.html
   desc: 'SWT-Bench Verified: human-validated subset of SWT-Bench evaluating LLMs on generating reproducing unit tests for real GitHub issues — tests must fail on buggy code and pass after the fix.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -168,6 +168,13 @@
   version: latest
   categories:
   - Mathematics
+- title: ale/rsi-post-training
+  path: registry/ale_rsi_post_training.html
+  desc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows.
+  desc_trunc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-trai…
+  task_function: ale_rsi_post_training
+  samples: 5
+  version: latest
 - title: algotune/algotune
   path: registry/algotune.html
   desc: 'AlgoTune: NeurIPS 2025 benchmark of math/physics/CS problems where the model writes code that matches reference output but runs faster than existing implementations.'
@@ -208,6 +215,13 @@
   categories:
   - Reasoning
   - Multimodal
+- title: atm-bench/atm-bench-hard-sgm
+  path: registry/atm_bench_atm_bench_hard_sgm.html
+  desc: ATM-Bench-Hard SGM Harbor tasks.
+  desc_trunc: ATM-Bench-Hard SGM Harbor tasks.
+  task_function: atm_bench_atm_bench_hard_sgm
+  samples: 31
+  version: latest
 - title: benchflow/skillsbench
   path: registry/benchflow_skillsbench.html
   desc: 'SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folders of instructions, scripts, and resources) to complete specialized workflows spanning science, engineering, and professional domains.'
@@ -487,8 +501,8 @@
   - Coding
 - title: harbor-index/harbor-index
   path: registry/harbor_index.html
-  desc: 'Harbor Index: 80 agentic software-engineering and science tasks with executable verifiers (revision 1.2).'
-  desc_trunc: 'Harbor Index: 80 agentic software-engineering and science tasks with executable verifiers (revision…'
+  desc: 'Harbor Index: 80 agentic tasks spanning software engineering, science, and tool use (revision 1.3).'
+  desc_trunc: 'Harbor Index: 80 agentic tasks spanning software engineering, science, and tool use (revision 1.3).'
   task_function: harbor_index
   samples: 80
   version: latest
@@ -753,6 +767,13 @@
   version: latest
   categories:
   - Coding
+- title: punitarani/harvey-labs
+  path: registry/punitarani_harvey_labs.html
+  desc: 'Harvey Labs: 1,760 legal-drafting tasks (LAB) across 26 practice areas, graded with Harbor rewardkit (LLM-judge, OpenRouter default, 111,826 binary criteria).'
+  desc_trunc: 'Harvey Labs: 1,760 legal-drafting tasks (LAB) across 26 practice areas, graded with Harbor rewardki…'
+  task_function: punitarani_harvey_labs
+  samples: 1760
+  version: latest
 - title: qcircuitbench/qcircuitbench
   path: registry/qcircuitbench.html
   desc: 'QCircuitBench: large-scale benchmark for LLM-driven quantum-algorithm design, spanning oracle construction, algorithm design, and random circuits with automatic verification.'
@@ -973,6 +994,13 @@
   version: latest
   categories:
   - Coding
+- title: swesimbench/SWESimBench
+  path: registry/swesimbench_swesimbench.html
+  desc: 'SWESimBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks).'
+  desc_trunc: 'SWESimBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks).'
+  task_function: swesimbench_swesimbench
+  samples: 1520
+  version: latest
 - title: swt-bench/swt-bench-verified
   path: registry/swt_bench_verified.html
   desc: 'SWT-Bench Verified: human-validated subset of SWT-Bench evaluating LLMs on generating reproducing unit tests for real GitHub issues — tests must fail on buggy code and pass after the fix.'
@@ -1068,6 +1096,13 @@
   version: latest
   categories:
   - Coding
+- title: userbench/UserBench
+  path: registry/userbench_userbench.html
+  desc: 'UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as SWESimBench v2.'
+  desc_trunc: 'UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as…'
+  task_function: userbench_userbench
+  samples: 1520
+  version: latest
 - title: vals/financeagent
   path: registry/vals_financeagent.html
   desc: 'Vals AI Finance Agent Benchmark: expert-validated finance questions across nine task categories (retrieval, market research, projections) with EDGAR/SEC search tools for evaluating financial agents.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -1089,10 +1089,10 @@
   categories:
   - Coding
 - title: userbench/UserBench
-  path: registry/userbench_userbench.html
+  path: registry/userbench.html
   desc: 'UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as SWESimBench v2.'
   desc_trunc: 'UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as…'
-  task_function: userbench_userbench
+  task_function: userbench
   samples: 1520
   version: latest
 - title: vals/financeagent

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -695,7 +695,7 @@ def arcprize_arc_agi_2(
 
 
 @task
-def atm_bench_atm_bench_hard_sgm(
+def atm_bench_hard_sgm(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -706,7 +706,7 @@ def atm_bench_atm_bench_hard_sgm(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""ATM-Bench-Hard SGM Harbor tasks
+    r"""ATM-Bench-Hard (SGM): 31 hard long-term personalized memory questions answered from schema-guided memory (SGM) files distilled from ~4 years of a user's images, videos, and emails.
 
     Slug: atm-bench/atm-bench-hard-sgm
     Latest digest: sha256:745358f9028fc12c5bb83ddb9d401e43791d0383e61a70b9f83d0d927af2d821
@@ -2493,37 +2493,6 @@ def pgcodellm_rebench_v2_test(
 
 
 @task
-def punitarani_harvey_labs(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Harvey Labs: 1,760 legal-drafting tasks (LAB) across 26 practice areas, graded with Harbor rewardkit (LLM-judge, OpenRouter default, 111,826 binary criteria).
-
-    Slug: punitarani/harvey-labs
-    Latest digest: sha256:a5ffde4541a825f3917c35e81b48b5ff79145502386881f03c1af6c6d3aeab9f
-    """
-    return _harbor_base(
-        package_name="punitarani/harvey-labs",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def qcircuitbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3230,37 +3199,6 @@ def swe_rebench_leaderboard(
     """
     return _harbor_base(
         package_name="swe-rebench/swe-rebench-leaderboard",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def swesimbench_swesimbench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""SWESimBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks).
-
-    Slug: swesimbench/SWESimBench
-    Latest digest: sha256:7dc55b1a88bce838cebf8ceb1901d49236804e1a59c63a8debda0d09c9a4581d
-    """
-    return _harbor_base(
-        package_name="swesimbench/SWESimBench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3522,7 +3522,7 @@ def usaco(
 
 
 @task
-def userbench_userbench(
+def userbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3533,13 +3533,44 @@ def userbench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as SWESimBench v2.
+    r"""UserBench eval: 620 noprofile next-message tasks across 62 developers (exactly 10 shortest-history points per developer with ≥10 eval points).
 
     Slug: userbench/UserBench
-    Latest digest: sha256:f6125049e4932a9401c9dece81ddb0ce1329e19d0dd68552222d3e84be257ea7
+    Latest digest: sha256:b37b5035bb3444f3ca3af8ee0a37084c621b18fc55ad2b5c6fcf031066894fa9
     """
     return _harbor_base(
         package_name="userbench/UserBench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def userbench_train400(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""UserBench train400 twin: same 620 held tasks as UserBench@v2 plus leak-safe /sim/train/ with 400 human-turns (sqrt two-stage) per developer.
+
+    Slug: userbench/UserBench-train400
+    Latest digest: sha256:b4d19cf9e2835a8a1d3d5a98bf373094ba1470b2ae98fcb3dff9e4f9d077007a
+    """
+    return _harbor_base(
+        package_name="userbench/UserBench-train400",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -27,7 +27,7 @@ def enterprise_bench_l1_l2_bench(
     r"""Enterprise-Bench (L1-L2): DevRev's enterprise agent benchmark — answering L1/L2 support-tier questions (ticket SLAs, triage, customer-account data) over fragmented enterprise systems.
 
     Slug: Enterprise-Bench/l1-l2-bench
-    Latest digest: sha256:9a32367dd69321635b518dcd2befab16d50fdda623139e92025a81e6492659ec
+    Latest digest: sha256:834e40f54800287c913cebc9fa8e8273292940436168a56c1c5c72ff8a687e8d
     """
     return _harbor_base(
         package_name="Enterprise-Bench/l1-l2-bench",
@@ -540,6 +540,37 @@ def aime(
 
 
 @task
+def ale_rsi_post_training(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows
+
+    Slug: ale/rsi-post-training
+    Latest digest: sha256:206d8bfff7b849cd08ea5e50edea019daf392f2e334257386854a7473a632f41
+    """
+    return _harbor_base(
+        package_name="ale/rsi-post-training",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def algotune(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -651,6 +682,37 @@ def arcprize_arc_agi_2(
     """
     return _harbor_base(
         package_name="arcprize/arc-agi-2",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def atm_bench_atm_bench_hard_sgm(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""ATM-Bench-Hard SGM Harbor tasks
+
+    Slug: atm-bench/atm-bench-hard-sgm
+    Latest digest: sha256:745358f9028fc12c5bb83ddb9d401e43791d0383e61a70b9f83d0d927af2d821
+    """
+    return _harbor_base(
+        package_name="atm-bench/atm-bench-hard-sgm",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -1574,10 +1636,10 @@ def harbor_index(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""Harbor Index: 80 agentic software-engineering and science tasks with executable verifiers (revision 1.2).
+    r"""Harbor Index: 80 agentic tasks spanning software engineering, science, and tool use (revision 1.3).
 
     Slug: harbor-index/harbor-index
-    Latest digest: sha256:45f546a3b68abba79a5cbf756c7058cc4884358bd78e510f4cc7342766837acc
+    Latest digest: sha256:fdb3554453d29f96bfe87ddf36e6770f6ceadd375e8189c62718ef2f215bbbad
     """
     return _harbor_base(
         package_name="harbor-index/harbor-index",
@@ -2431,6 +2493,37 @@ def pgcodellm_rebench_v2_test(
 
 
 @task
+def punitarani_harvey_labs(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Harvey Labs: 1,760 legal-drafting tasks (LAB) across 26 practice areas, graded with Harbor rewardkit (LLM-judge, OpenRouter default, 111,826 binary criteria).
+
+    Slug: punitarani/harvey-labs
+    Latest digest: sha256:a5ffde4541a825f3917c35e81b48b5ff79145502386881f03c1af6c6d3aeab9f
+    """
+    return _harbor_base(
+        package_name="punitarani/harvey-labs",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def qcircuitbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3150,6 +3243,37 @@ def swe_rebench_leaderboard(
 
 
 @task
+def swesimbench_swesimbench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""SWESimBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks).
+
+    Slug: swesimbench/SWESimBench
+    Latest digest: sha256:7dc55b1a88bce838cebf8ceb1901d49236804e1a59c63a8debda0d09c9a4581d
+    """
+    return _harbor_base(
+        package_name="swesimbench/SWESimBench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def swt_bench_verified(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3447,6 +3571,37 @@ def usaco(
     """
     return _harbor_base(
         package_name="usaco/usaco",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def userbench_userbench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""UserBench eval (v2): noprofile user-simulation held-out turns (~1520 tasks). Formerly developed as SWESimBench v2.
+
+    Slug: userbench/UserBench
+    Latest digest: sha256:f6125049e4932a9401c9dece81ddb0ce1329e19d0dd68552222d3e84be257ea7
+    """
+    return _harbor_base(
+        package_name="userbench/UserBench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
ale/rsi-post-training
atm-bench/atm-bench-hard-sgm
punitarani/harvey-labs
swesimbench/SWESimBench
userbench/UserBench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks