### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -951,6 +951,9 @@ terminal-bench/terminal-bench-2-1:
   function_name: terminal_bench_2_1
   title: Terminal-Bench v2.1
 
+terminal-bench/terminal-bench-3:
+  categories: []
+
 theagentcompany/theagentcompany:
   categories:
   - Professional

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -952,7 +952,13 @@ terminal-bench/terminal-bench-2-1:
   title: Terminal-Bench v2.1
 
 terminal-bench/terminal-bench-3:
-  categories: []
+  categories:
+  - Coding
+  - Assistants
+  arxiv: https://arxiv.org/abs/2601.11868
+  repo: https://github.com/harbor-framework/terminal-bench-3
+  function_name: terminal_bench_3
+  title: Terminal-Bench 3
 
 theagentcompany/theagentcompany:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -1041,12 +1041,15 @@
   - Coding
   - Assistants
 - title: terminal-bench/terminal-bench-3
-  path: registry/terminal_bench_terminal_bench_3.html
+  path: registry/terminal_bench_3.html
   desc: Terminal-Bench 3.0 is the third benchmark for measuring agents' abilities to complete tasks using a terminal.
   desc_trunc: Terminal-Bench 3.0 is the third benchmark for measuring agents' abilities to complete tasks using a…
-  task_function: terminal_bench_terminal_bench_3
+  task_function: terminal_bench_3
   samples: 75
   version: latest
+  categories:
+  - Coding
+  - Assistants
 - title: terminal-bench-pro/terminal-bench-pro
   path: registry/terminal_bench_pro.html
   desc: 'Terminal-Bench Pro: tasks across 8 domains — data processing, games, debugging, sysadmin, scientific computing, SWE, ML, and security — extending Terminal-Bench with harder real-world scenarios.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -173,7 +173,7 @@
   desc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows.
   desc_trunc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-trai…
   task_function: ale_rsi_post_training
-  samples: 5
+  samples: 6
   version: latest
   categories:
   - Coding
@@ -1040,6 +1040,13 @@
   categories:
   - Coding
   - Assistants
+- title: terminal-bench/terminal-bench-3
+  path: registry/terminal_bench_terminal_bench_3.html
+  desc: Terminal-Bench 3.0 is the third benchmark for measuring agents' abilities to complete tasks using a terminal.
+  desc_trunc: Terminal-Bench 3.0 is the third benchmark for measuring agents' abilities to complete tasks using a…
+  task_function: terminal_bench_terminal_bench_3
+  samples: 75
+  version: latest
 - title: terminal-bench-pro/terminal-bench-pro
   path: registry/terminal_bench_pro.html
   desc: 'Terminal-Bench Pro: tasks across 8 domains — data processing, games, debugging, sysadmin, scientific computing, SWE, ML, and security — extending Terminal-Bench with harder real-world scenarios.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -554,7 +554,7 @@ def ale_rsi_post_training(
     r"""ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows
 
     Slug: ale/rsi-post-training
-    Latest digest: sha256:206d8bfff7b849cd08ea5e50edea019daf392f2e334257386854a7473a632f41
+    Latest digest: sha256:8f9485dd374141adf8bf8f6475eb6d107a59351ce585674586fb3175222bce4c
     """
     return _harbor_base(
         package_name="ale/rsi-post-training",
@@ -3354,6 +3354,37 @@ def terminal_bench_2_1(
     """
     return _harbor_base(
         package_name="terminal-bench/terminal-bench-2-1",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def terminal_bench_terminal_bench_3(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Terminal-Bench 3.0 is the third benchmark for measuring agents' abilities to complete tasks using a terminal.
+
+    Slug: terminal-bench/terminal-bench-3
+    Latest digest: sha256:88433fbcecd1a3f81f7a71bff4cc76c394d0edbefb7e028f90d4109b639fefba
+    """
+    return _harbor_base(
+        package_name="terminal-bench/terminal-bench-3",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3367,7 +3367,7 @@ def terminal_bench_2_1(
 
 
 @task
-def terminal_bench_terminal_bench_3(
+def terminal_bench_3(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
terminal-bench/terminal-bench-3
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks