### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -378,6 +378,9 @@ featurebench/featurebench-modal:
   function_name: featurebench_modal
   title: FeatureBench (Modal)
 
+frontier-bench/frontier-bench:
+  categories: []
+
 futurehouse/bixbench:
   categories:
   - Science
@@ -503,6 +506,9 @@ ineqmath/ineqmath:
   desc: 'IneqMath: Olympiad-level inequality benchmark with expert-reviewed test problems, formulated as bound-estimation and relation-prediction subtasks with stepwise judging.'
   function_name: ineqmath
   title: IneqMath
+
+infra-bench/infra-bench-v1:
+  categories: []
 
 islo-labs/reward-hack-bench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -379,7 +379,12 @@ featurebench/featurebench-modal:
   title: FeatureBench (Modal)
 
 frontier-bench/frontier-bench:
-  categories: []
+  categories:
+  - Coding
+  - Assistants
+  repo: https://github.com/harbor-framework/frontier-bench
+  function_name: frontier_bench
+  title: Frontier-Bench
 
 futurehouse/bixbench:
   categories:
@@ -508,7 +513,12 @@ ineqmath/ineqmath:
   title: IneqMath
 
 infra-bench/infra-bench-v1:
-  categories: []
+  categories:
+  - Coding
+  - Professional
+  repo: https://github.com/sammysun0711/InfraBench
+  function_name: infra_bench_v1
+  title: InfraBench v1
 
 islo-labs/reward-hack-bench:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -393,6 +393,13 @@
   version: latest
   categories:
   - Coding
+- title: frontier-bench/frontier-bench
+  path: registry/frontier_bench_frontier_bench.html
+  desc: 'Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.'
+  desc_trunc: 'Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.'
+  task_function: frontier_bench_frontier_bench
+  samples: 74
+  version: latest
 - title: futurehouse/bixbench
   path: registry/futurehouse_bixbench.html
   desc: 'BixBench: real-world bioinformatics analysis capsules with open-answer questions evaluating LLM agents'' ability to author multi-step Jupyter notebooks for biological data analysis.'
@@ -545,6 +552,13 @@
   categories:
   - Mathematics
   - Reasoning
+- title: infra-bench/infra-bench-v1
+  path: registry/infra_bench_infra_bench_v1.html
+  desc: '20 AI-infra engineering tasks on AMD MI35X (5 categories: model deployment, profiling, kernel implementation, kernel tuning, debug triage).'
+  desc_trunc: '20 AI-infra engineering tasks on AMD MI35X (5 categories: model deployment, profiling, kernel imple…'
+  task_function: infra_bench_infra_bench_v1
+  samples: 20
+  version: latest
 - title: islo-labs/reward-hack-bench
   path: registry/islo_labs_reward_hack_bench.html
   desc: 'Reward-hacking benchmark: SWE-bench + CyBench tasks with injected solution-retrieval cheat prompts, scored by a fairness LLM judge. Reward = solved without cheating.'
@@ -1100,8 +1114,8 @@
   - Coding
 - title: userbench/UserBench
   path: registry/userbench.html
-  desc: 'UserBench eval: 620 noprofile next-message tasks across 62 developers (exactly 10 shortest-history points per developer with ≥10 eval points).'
-  desc_trunc: 'UserBench eval: 620 noprofile next-message tasks across 62 developers (exactly 10 shortest-history…'
+  desc: 'UserBench eval: 620 next-message tasks across 62 developers. Composer 2.5 classifies gold and predicted messages into multi-label acts; reward is set Jaccard/IoU.'
+  desc_trunc: 'UserBench eval: 620 next-message tasks across 62 developers. Composer 2.5 classifies gold and predi…'
   task_function: userbench
   samples: 620
   version: latest
@@ -1110,8 +1124,8 @@
   - Coding
 - title: userbench/UserBench-train400
   path: registry/userbench_train400.html
-  desc: 'UserBench train400 twin: same 620 held tasks as UserBench@v2 plus leak-safe /sim/train/ with 400 human-turns (sqrt two-stage) per developer.'
-  desc_trunc: 'UserBench train400 twin: same 620 held tasks as UserBench@v2 plus leak-safe /sim/train/ with 400 hu…'
+  desc: 'UserBench train400 twin: the same 620 held tasks plus 400 leak-safe prior turns per developer. Composer 2.5 multi-label acts score by set Jaccard/IoU.'
+  desc_trunc: 'UserBench train400 twin: the same 620 held tasks plus 400 leak-safe prior turns per developer. Comp…'
   task_function: userbench_train400
   samples: 620
   version: latest

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -394,12 +394,15 @@
   categories:
   - Coding
 - title: frontier-bench/frontier-bench
-  path: registry/frontier_bench_frontier_bench.html
+  path: registry/frontier_bench.html
   desc: 'Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.'
   desc_trunc: 'Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.'
-  task_function: frontier_bench_frontier_bench
+  task_function: frontier_bench
   samples: 74
   version: latest
+  categories:
+  - Coding
+  - Assistants
 - title: futurehouse/bixbench
   path: registry/futurehouse_bixbench.html
   desc: 'BixBench: real-world bioinformatics analysis capsules with open-answer questions evaluating LLM agents'' ability to author multi-step Jupyter notebooks for biological data analysis.'
@@ -553,12 +556,15 @@
   - Mathematics
   - Reasoning
 - title: infra-bench/infra-bench-v1
-  path: registry/infra_bench_infra_bench_v1.html
+  path: registry/infra_bench_v1.html
   desc: '20 AI-infra engineering tasks on AMD MI35X (5 categories: model deployment, profiling, kernel implementation, kernel tuning, debug triage).'
   desc_trunc: '20 AI-infra engineering tasks on AMD MI35X (5 categories: model deployment, profiling, kernel imple…'
-  task_function: infra_bench_infra_bench_v1
+  task_function: infra_bench_v1
   samples: 20
   version: latest
+  categories:
+  - Coding
+  - Professional
 - title: islo-labs/reward-hack-bench
   path: registry/islo_labs_reward_hack_bench.html
   desc: 'Reward-hacking benchmark: SWE-bench + CyBench tasks with injected solution-retrieval cheat prompts, scored by a fairness LLM judge. Reward = solved without cheating.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1284,6 +1284,37 @@ def featurebench_modal(
 
 
 @task
+def frontier_bench_frontier_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.
+
+    Slug: frontier-bench/frontier-bench
+    Latest digest: sha256:97fd2ba3aabdda16823a1a8ea695a3875e50e800caa60b450686deedc7171763
+    """
+    return _harbor_base(
+        package_name="frontier-bench/frontier-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def futurehouse_bixbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1736,6 +1767,37 @@ def ineqmath(
     """
     return _harbor_base(
         package_name="ineqmath/ineqmath",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def infra_bench_infra_bench_v1(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""20 AI-infra engineering tasks on AMD MI35X (5 categories: model deployment, profiling, kernel implementation, kernel tuning, debug triage)
+
+    Slug: infra-bench/infra-bench-v1
+    Latest digest: sha256:ee4dab2ad2279aaf0bc52c2736083844e9555ef86236e8ee7867bd0ba7afde87
+    """
+    return _harbor_base(
+        package_name="infra-bench/infra-bench-v1",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -3564,10 +3626,10 @@ def userbench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""UserBench eval: 620 noprofile next-message tasks across 62 developers (exactly 10 shortest-history points per developer with ≥10 eval points).
+    r"""UserBench eval: 620 next-message tasks across 62 developers. Composer 2.5 classifies gold and predicted messages into multi-label acts; reward is set Jaccard/IoU.
 
     Slug: userbench/UserBench
-    Latest digest: sha256:b37b5035bb3444f3ca3af8ee0a37084c621b18fc55ad2b5c6fcf031066894fa9
+    Latest digest: sha256:5ae6956f943da5d0781cf835cd8025a0411160321bb048f12c77bde7aac46bda
     """
     return _harbor_base(
         package_name="userbench/UserBench",
@@ -3595,10 +3657,10 @@ def userbench_train400(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""UserBench train400 twin: same 620 held tasks as UserBench@v2 plus leak-safe /sim/train/ with 400 human-turns (sqrt two-stage) per developer.
+    r"""UserBench train400 twin: the same 620 held tasks plus 400 leak-safe prior turns per developer. Composer 2.5 multi-label acts score by set Jaccard/IoU.
 
     Slug: userbench/UserBench-train400
-    Latest digest: sha256:b4d19cf9e2835a8a1d3d5a98bf373094ba1470b2ae98fcb3dff9e4f9d077007a
+    Latest digest: sha256:ed4a2f13efe35bec348b5da764c9ccb290443a9d42d622f055eb701dc5c0d2ab
     """
     return _harbor_base(
         package_name="userbench/UserBench-train400",

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1284,7 +1284,7 @@ def featurebench_modal(
 
 
 @task
-def frontier_bench_frontier_bench(
+def frontier_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -1780,7 +1780,7 @@ def ineqmath(
 
 
 @task
-def infra_bench_infra_bench_v1(
+def infra_bench_v1(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
frontier-bench/frontier-bench
infra-bench/infra-bench-v1
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks