### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -53,3 +53,9 @@
 # "Formerly developed as SWESimBench v2". userbench/UserBench is kept
 # (categorized in overrides.yml); this stale-name copy goes regardless.
 - swesimbench/SWESimBench
+# 1-task subset re-upload of ale/rsi-post-training by the same publisher two
+# days later (identical input to ale/olmo3-7b-zero-rl-acc, same verbatim
+# desc); the rsi-index GitHub org has no public repos. Keep the complete
+# 6-task ale/rsi-post-training. Revisit if rsi-index becomes the canonical
+# home of the ALE RSI benchmark.
+- rsi-index/post-training

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -784,9 +784,6 @@ rexbench/rexbench:
   function_name: rexbench
   title: RExBench
 
-rsi-index/post-training:
-  categories: []
-
 satbench/satbench:
   categories:
   - Reasoning

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -784,6 +784,9 @@ rexbench/rexbench:
   function_name: rexbench
   title: RExBench
 
+rsi-index/post-training:
+  categories: []
+
 satbench/satbench:
   categories:
   - Reasoning

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -869,13 +869,6 @@
   version: latest
   categories:
   - Coding
-- title: rsi-index/post-training
-  path: registry/rsi_index_post_training.html
-  desc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows.
-  desc_trunc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-trai…
-  task_function: rsi_index_post_training
-  samples: 1
-  version: latest
 - title: satbench/satbench
   path: registry/satbench.html
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -395,8 +395,8 @@
   - Coding
 - title: frontier-bench/frontier-bench
   path: registry/frontier_bench.html
-  desc: 'Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.'
-  desc_trunc: 'Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.'
+  desc: The frontier is wide and dynamic. Frontier-Bench measures general agent capabilities on a diverse set of difficult tasks.
+  desc_trunc: The frontier is wide and dynamic. Frontier-Bench measures general agent capabilities on a diverse s…
   task_function: frontier_bench
   samples: 74
   version: latest
@@ -869,6 +869,13 @@
   version: latest
   categories:
   - Coding
+- title: rsi-index/post-training
+  path: registry/rsi_index_post_training.html
+  desc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows.
+  desc_trunc: ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-trai…
+  task_function: rsi_index_post_training
+  samples: 1
+  version: latest
 - title: satbench/satbench
   path: registry/satbench.html
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1295,10 +1295,10 @@ def frontier_bench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""Frontier-Bench: a digest-pinned suite of hard agentic terminal tasks.
+    r"""The frontier is wide and dynamic. Frontier-Bench measures general agent capabilities on a diverse set of difficult tasks.
 
     Slug: frontier-bench/frontier-bench
-    Latest digest: sha256:97fd2ba3aabdda16823a1a8ea695a3875e50e800caa60b450686deedc7171763
+    Latest digest: sha256:63f363a191f0a0429fd1c5b318080616bab839473ce27e39f44868d327b03a89
     """
     return _harbor_base(
         package_name="frontier-bench/frontier-bench",
@@ -2796,6 +2796,37 @@ def rexbench(
     """
     return _harbor_base(
         package_name="rexbench/rexbench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def rsi_index_post_training(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows
+
+    Slug: rsi-index/post-training
+    Latest digest: sha256:46e29b6a00e487dbf4ab88c40c1a525941df5f3d7ce6956b42c35d5432031bfb
+    """
+    return _harbor_base(
+        package_name="rsi-index/post-training",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2809,37 +2809,6 @@ def rexbench(
 
 
 @task
-def rsi_index_post_training(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""ALE RSI post-training benchmark tasks for evaluating agent capabilities in research-level post-training workflows
-
-    Slug: rsi-index/post-training
-    Latest digest: sha256:46e29b6a00e487dbf4ab88c40c1a525941df5f3d7ce6956b42c35d5432031bfb
-    """
-    return _harbor_base(
-        package_name="rsi-index/post-training",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def satbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
rsi-index/post-training
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks