### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -785,7 +785,10 @@ rexbench/rexbench:
   title: RExBench
 
 rounakbende10/rh-swe-bench:
-  categories: []
+  categories:
+  - Coding
+  title: RH SWE-bench
+  repo: https://github.com/rounakbende10/rh-swe-bench
 
 satbench/satbench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -784,6 +784,9 @@ rexbench/rexbench:
   function_name: rexbench
   title: RExBench
 
+rounakbende10/rh-swe-bench:
+  categories: []
+
 satbench/satbench:
   categories:
   - Reasoning

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -876,6 +876,8 @@
   task_function: rounakbende10_rh_swe_bench
   samples: 357
   version: latest
+  categories:
+  - Coding
 - title: satbench/satbench
   path: registry/satbench.html
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -869,6 +869,13 @@
   version: latest
   categories:
   - Coding
+- title: rounakbende10/rh-swe-bench
+  path: registry/rounakbende10_rh_swe_bench.html
+  desc: Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos.
+  desc_trunc: Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos.
+  task_function: rounakbende10_rh_swe_bench
+  samples: 357
+  version: latest
 - title: satbench/satbench
   path: registry/satbench.html
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2809,6 +2809,37 @@ def rexbench(
 
 
 @task
+def rounakbende10_rh_swe_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos
+
+    Slug: rounakbende10/rh-swe-bench
+    Latest digest: sha256:35fa496a85a348f06ee47ef69e8899c573ecceb0a1d3c5102482928492267667
+    """
+    return _harbor_base(
+        package_name="rounakbende10/rh-swe-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def satbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
rounakbende10/rh-swe-bench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks