### PR TITLE
feat: map task.toml healthcheck to the compose service healthcheck

### DIFF
--- a/docs/tasks.qmd
+++ b/docs/tasks.qmd
@@ -60,11 +60,22 @@ Loading a task that declares any of the below either raises or warns:
 |---|---|
 | `[[steps]]` + `multi_step_reward_strategy` (multi-step tasks) | **raise** |
 | `[environment].os = "windows"` | **raise** |
-| `[environment].healthcheck` | warn (agent may run before services ready) |
 | `[environment].mcp_servers` | warn (not exposed to agent) |
 | `[environment].skills_dir` | warn (not copied to agent skills dir) |
 
 `[environment].build_timeout_sec`, `storage_mb`, `workdir`, and `config.source` / `config.artifacts` are ignored.
+
+### Healthchecks
+
+`[environment].healthcheck` maps onto the `healthcheck` of the default compose
+service: `command` becomes a `CMD-SHELL` test and the `*_sec` fields become
+compose durations. Inspect brings the environment up with `docker compose up
+--wait`, so the agent only starts once the check passes — matching Harbor,
+which polls the same command before agent setup.
+
+If a task ships a `docker-compose.yaml` that already declares a healthcheck on
+the default service, that one is kept (a service has only one healthcheck) and
+the `task.toml` healthcheck is ignored with a warning.
 
 ## LLM Judges in Verification
 

--- a/docs/tasks.qmd
+++ b/docs/tasks.qmd
@@ -70,12 +70,19 @@ Loading a task that declares any of the below either raises or warns:
 `[environment].healthcheck` maps onto the `healthcheck` of the default compose
 service: `command` becomes a `CMD-SHELL` test and the `*_sec` fields become
 compose durations. Inspect brings the environment up with `docker compose up
---wait`, so the agent only starts once the check passes — matching Harbor,
-which polls the same command before agent setup.
+--wait`, so the agent only starts once the check passes, as it does under
+Harbor. Two differences are worth knowing about:
 
-If a task ships a `docker-compose.yaml` that already declares a healthcheck on
-the default service, that one is kept (a service has only one healthcheck) and
-the `task.toml` healthcheck is ignored with a warning.
+- If a task ships a `docker-compose.yaml` that already declares a healthcheck
+  on the default service, that one is kept and the `task.toml` healthcheck is
+  not enforced (a compose service carries only one healthcheck, whereas Harbor
+  gates readiness on both). Loading such a task warns.
+- Inspect sizes its `compose up --wait` timeout as `retries * (interval +
+  timeout)`, which does not include `start_period_sec`. A task whose grace
+  period is longer than that product can therefore be cut short at startup,
+  even while Docker still considers the container starting — with Harbor's
+  defaults, a `start_period_sec` above 105s. Harbor itself runs `up --wait`
+  untimed and only then polls the healthcheck, so it has no such ceiling.
 
 ## LLM Judges in Verification
 

--- a/src/inspect_harbor/_harbor/converters.py
+++ b/src/inspect_harbor/_harbor/converters.py
@@ -2,11 +2,16 @@
 
 import os
 import re
+import warnings
 from typing import Any
 
 import yaml
 from harbor.environments.docker.docker import _sanitize_docker_image_name
-from harbor.models.task.config import EnvironmentConfig, NetworkMode
+from harbor.models.task.config import (
+    EnvironmentConfig,
+    HealthcheckConfig,
+    NetworkMode,
+)
 from harbor.models.task.task import Task as HarborTask
 from harbor.models.trial.paths import EnvironmentPaths
 from inspect_ai.dataset import Sample
@@ -19,6 +24,7 @@ from inspect_ai.util import (
 from inspect_ai.util._sandbox.compose import (
     ComposeDeploy,
     ComposeDeviceReservation,
+    ComposeHealthcheck,
     ComposeResourceConfig,
     ComposeResourceReservations,
 )
@@ -83,6 +89,23 @@ def harbor_to_compose_config(
                 default_service.mem_limit = f"{memory_mb}m"
             if gpu_deploy:
                 default_service.deploy = gpu_deploy
+            if env_config.healthcheck is not None:
+                if default_service.healthcheck is None:
+                    default_service.healthcheck = _harbor_healthcheck_to_compose(
+                        env_config.healthcheck
+                    )
+                else:
+                    # A compose service can only carry one healthcheck, and the
+                    # one the task ships is the more specific declaration.
+                    warnings.warn(
+                        f"'{harbor_task.name}' declares both "
+                        "`[environment].healthcheck` in task.toml and a "
+                        "healthcheck on the default service of its "
+                        "docker-compose.yaml; keeping the compose healthcheck "
+                        "and ignoring the task.toml one.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
 
             # Network isolation applies to all services.
             if _is_no_network(env_config):
@@ -127,6 +150,11 @@ def harbor_to_compose_config(
             network_mode="none" if _is_no_network(env_config) else "bridge",
             deploy=gpu_deploy,
             environment=resolved_env,
+            healthcheck=(
+                _harbor_healthcheck_to_compose(env_config.healthcheck)
+                if env_config.healthcheck is not None
+                else None
+            ),
         )
 
         return ComposeConfig(services={"default": service})
@@ -210,6 +238,50 @@ def _find_default_service(config: ComposeConfig) -> tuple[str, ComposeService]:
             return candidate, config.services[candidate]
     name = next(iter(config.services))
     return name, config.services[name]
+
+
+def _harbor_healthcheck_to_compose(
+    healthcheck: HealthcheckConfig,
+) -> ComposeHealthcheck:
+    """Map a Harbor ``[environment].healthcheck`` onto a compose healthcheck.
+
+    Harbor polls the command itself before agent setup, explicitly mirroring
+    Docker's HEALTHCHECK semantics, so the fields map one-to-one. Inspect
+    brings the environment up with ``docker compose up --wait``, which gates
+    readiness on the healthcheck — so the agent no longer starts before the
+    services it depends on are ready.
+
+    Harbor's ``command`` is a shell command string, hence ``CMD-SHELL``.
+    """
+    return ComposeHealthcheck(
+        test=["CMD-SHELL", healthcheck.command],
+        interval=_compose_duration(healthcheck.interval_sec),
+        timeout=_compose_duration(healthcheck.timeout_sec),
+        start_period=_compose_duration(healthcheck.start_period_sec),
+        # ``start_interval`` only applies within the start period (in Docker and
+        # in Harbor's own loop), so omit it when there is no start period —
+        # it would be inert and it needs Docker Engine 25+.
+        start_interval=(
+            _compose_duration(healthcheck.start_interval_sec)
+            if healthcheck.start_period_sec > 0
+            else None
+        ),
+        retries=healthcheck.retries,
+    )
+
+
+def _compose_duration(seconds: float) -> str:
+    r"""Render a Harbor ``*_sec`` float as a compose duration string.
+
+    Emits whole units only: Inspect's compose duration parser matches
+    ``(\d+)([a-z]+)``, so a fractional string like ``"5.5s"`` would silently
+    parse as ``5s`` (and ``"5.0s"`` as ``0s``, since ``5`` isn't followed by a
+    unit), skewing the ``up --wait`` timeout.
+    """
+    milliseconds = round(seconds * 1000)
+    if milliseconds % 1000 == 0:
+        return f"{milliseconds // 1000}s"
+    return f"{milliseconds}ms"
 
 
 def _create_gpu_deploy_config(

--- a/src/inspect_harbor/_harbor/task.py
+++ b/src/inspect_harbor/_harbor/task.py
@@ -235,7 +235,6 @@ def _build_harbor_tasks(
 
     multi_step: list[str] = []
     windows: list[str] = []
-    healthcheck: list[str] = []
     mcp_servers: list[str] = []
     skills_dir: list[str] = []
     allowlist: list[str] = []
@@ -246,8 +245,6 @@ def _build_harbor_tasks(
         env = t.config.environment
         if str(getattr(env.os, "value", env.os)).lower() == "windows":
             windows.append(t.name)
-        if env.healthcheck is not None:
-            healthcheck.append(t.name)
         if env.mcp_servers:
             mcp_servers.append(t.name)
         if env.skills_dir is not None:
@@ -275,8 +272,6 @@ def _build_harbor_tasks(
         )
 
     degraded: list[str] = []
-    if healthcheck:
-        degraded.append(f"`[environment].healthcheck`: {healthcheck}")
     if mcp_servers:
         degraded.append(f"`[environment].mcp_servers`: {mcp_servers}")
     if skills_dir:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -9,6 +9,7 @@ import yaml
 from harbor.models.task.config import (
     AgentConfig,
     EnvironmentConfig,
+    HealthcheckConfig,
     NetworkMode,
     TaskConfig,
     VerifierConfig,
@@ -37,6 +38,7 @@ def test_harbor_to_compose_config_with_existing_compose_yaml():
     mock_env_config.memory_mb = 4096
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_env_config.network_mode = "public"
     mock_task.config.environment = mock_env_config
 
@@ -86,6 +88,7 @@ def test_harbor_to_compose_config_with_dockerfile():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     def exists_side_effect(self: Path) -> bool:
@@ -140,6 +143,7 @@ def test_harbor_to_compose_config_dockerfile_image_tag_is_deterministic():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     def exists_side_effect(self: Path) -> bool:
@@ -185,6 +189,7 @@ def test_harbor_to_compose_config_dockerfile_path_injects_task_env(
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     def exists_side_effect(self: Path) -> bool:
@@ -219,6 +224,7 @@ def test_harbor_to_compose_config_dockerfile_path_missing_env_var_raises(
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     def exists_side_effect(self: Path) -> bool:
@@ -245,6 +251,7 @@ def test_harbor_to_compose_config_with_prebuilt_image():
     mock_env_config.network_mode = "no-network"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -279,6 +286,7 @@ def test_harbor_to_compose_config_custom_resource_limits():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -369,6 +377,7 @@ def test_harbor_to_compose_config_compose_yaml_no_internet_overrides_network_mod
     mock_env_config.memory_mb = 2048
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_env_config.network_mode = "no-network"
     mock_task.config.environment = mock_env_config
 
@@ -404,6 +413,7 @@ def test_harbor_to_compose_config_compose_yaml_preserves_custom_network_mode():
     mock_env_config.memory_mb = 2048
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_env_config.network_mode = "public"
     mock_task.config.environment = mock_env_config
 
@@ -443,6 +453,7 @@ def test_harbor_to_compose_config_compose_yaml_no_network_mode_left_unset():
     mock_env_config.memory_mb = 2048
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_env_config.network_mode = "public"
     mock_task.config.environment = mock_env_config
 
@@ -478,6 +489,7 @@ def test_harbor_to_compose_config_network_mode_field_no_network():
     mock_env_config.network_mode = "no-network"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -506,6 +518,7 @@ def test_harbor_to_compose_config_network_mode_field_allows_network(
     mock_env_config.network_mode = network_mode
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -574,6 +587,7 @@ def test_compose_yaml_explicit_networks_not_clobbered_by_network_mode():
     mock_task.config.environment.memory_mb = 8192
     mock_task.config.environment.gpus = 0
     mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.healthcheck = None
     mock_task.config.environment.env = {}
     mock_task.config.environment.network_mode = "public"
     mock_task.config.verifier.env = {}
@@ -607,6 +621,7 @@ def test_compose_yaml_no_network_leaves_explicit_networks_alone():
     mock_task.config.environment.memory_mb = 8192
     mock_task.config.environment.gpus = 0
     mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.healthcheck = None
     mock_task.config.environment.env = {}
     mock_task.config.environment.network_mode = "no-network"
     mock_task.config.verifier.env = {}
@@ -665,6 +680,7 @@ def test_harbor_task_to_sample_metadata_preserved():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     mock_verifier_config = Mock()
@@ -715,6 +731,7 @@ def test_harbor_task_to_sample_sandbox_spec():
     mock_env_config.network_mode = "no-network"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     mock_verifier_config = Mock()
@@ -758,6 +775,7 @@ def test_harbor_to_compose_config_with_gpu_settings():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 2
     mock_env_config.gpu_types = ["H100", "A100"]
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -798,6 +816,7 @@ def test_harbor_to_compose_config_without_gpus():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -824,6 +843,7 @@ def test_harbor_to_compose_config_with_gpus_no_types():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 1
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -868,6 +888,7 @@ services:
     mock_task.config.environment.memory_mb = 2048
     mock_task.config.environment.gpus = 0
     mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.healthcheck = None
     mock_task.config.environment.docker_image = None
 
     with pytest.raises(yaml.YAMLError):
@@ -898,6 +919,7 @@ def test_harbor_task_to_sample_with_verifier_env():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     # Mock verifier config with env vars
@@ -947,6 +969,7 @@ def test_harbor_task_to_sample_without_verifier_env():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     # Mock verifier config without env vars (Harbor's default empty-dict).
@@ -989,6 +1012,7 @@ def test_harbor_task_to_sample_with_package_info():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     mock_task.config.verifier = Mock(timeout_sec=60, env={}, user=None)
@@ -1080,6 +1104,7 @@ def test_harbor_task_to_sample_user_fields(
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     mock_task.config.verifier = verifier_config
@@ -1120,6 +1145,7 @@ def mock_harbor_task():
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 1
     mock_env_config.gpu_types = ["H100"]
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     mock_verifier_config = Mock()
@@ -1242,6 +1268,7 @@ def _make_multi_service_task(
     mock_task.config.environment.memory_mb = memory_mb
     mock_task.config.environment.gpus = gpus
     mock_task.config.environment.gpu_types = gpu_types
+    mock_task.config.environment.healthcheck = None
     mock_task.config.environment.network_mode = network_mode
     mock_task.config.verifier.env = {}
     mock_task.config.environment.env = {}
@@ -1608,6 +1635,7 @@ services:
     mock_task.config.environment.memory_mb = 8192
     mock_task.config.environment.gpus = 0
     mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.healthcheck = None
     mock_task.config.environment.network_mode = "public"
     mock_task.config.environment.env = {}
     mock_task.config.verifier.env = {}
@@ -1658,6 +1686,7 @@ services:
     mock_task.config.environment.memory_mb = 6144
     mock_task.config.environment.gpus = 0
     mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.healthcheck = None
     mock_task.config.environment.network_mode = "public"
     mock_task.config.environment.env = {}
     mock_task.config.verifier.env = {}
@@ -1706,6 +1735,7 @@ services:
     mock_task.config.environment.memory_mb = 6144
     mock_task.config.environment.gpus = 0
     mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.healthcheck = None
     mock_task.config.environment.network_mode = "public"
     mock_task.config.environment.env = {}
     mock_task.config.verifier.env = {}
@@ -1744,6 +1774,7 @@ def test_harbor_to_compose_config_memory_minimum(
     mock_env_config.network_mode = "public"
     mock_env_config.gpus = 0
     mock_env_config.gpu_types = None
+    mock_env_config.healthcheck = None
     mock_task.config.environment = mock_env_config
 
     with patch("pathlib.Path.exists", return_value=False):
@@ -1751,3 +1782,161 @@ def test_harbor_to_compose_config_memory_minimum(
 
         service = result.services["default"]
         assert service.mem_limit == expected_memory
+
+
+def _make_healthcheck_task(
+    healthcheck: HealthcheckConfig | None,
+    name: str = "healthcheck-task",
+) -> Mock:
+    """A task mock whose ``[environment]`` carries only a healthcheck."""
+    mock_task = Mock()
+    mock_task.name = name
+    mock_task.paths = Mock()
+    mock_task.paths.environment_dir = Path("/task/environment")
+    mock_task.config.environment = Mock()
+    mock_task.config.environment.env = {}
+    mock_task.config.environment.cpus = None
+    mock_task.config.environment.memory_mb = None
+    mock_task.config.environment.docker_image = "ubuntu:latest"
+    mock_task.config.environment.gpus = 0
+    mock_task.config.environment.gpu_types = None
+    mock_task.config.environment.network_mode = "public"
+    mock_task.config.environment.healthcheck = healthcheck
+    mock_task.config.verifier.env = {}
+    return mock_task
+
+
+def test_healthcheck_mapped_on_programmatic_service():
+    """A task.toml healthcheck lands on the generated default service."""
+    mock_task = _make_healthcheck_task(
+        HealthcheckConfig(
+            command="curl -f http://localhost:8080/health",
+            interval_sec=2.0,
+            timeout_sec=10.0,
+            start_period_sec=30.0,
+            start_interval_sec=1.0,
+            retries=5,
+        )
+    )
+
+    with patch("pathlib.Path.exists", return_value=False):
+        result = harbor_to_compose_config(mock_task)
+
+    healthcheck = result.services["default"].healthcheck
+    assert healthcheck is not None
+    assert healthcheck.test == ["CMD-SHELL", "curl -f http://localhost:8080/health"]
+    assert healthcheck.interval == "2s"
+    assert healthcheck.timeout == "10s"
+    assert healthcheck.start_period == "30s"
+    assert healthcheck.start_interval == "1s"
+    assert healthcheck.retries == 5
+
+
+def test_healthcheck_absent_leaves_service_without_one():
+    """No task.toml healthcheck means no compose healthcheck."""
+    mock_task = _make_healthcheck_task(None)
+
+    with patch("pathlib.Path.exists", return_value=False):
+        result = harbor_to_compose_config(mock_task)
+
+    assert result.services["default"].healthcheck is None
+
+
+def test_healthcheck_defaults_omit_inert_start_interval():
+    """``start_interval`` is dropped when there is no start period.
+
+    Docker only uses it within the start period (as does Harbor's own loop),
+    and it requires Docker Engine 25+.
+    """
+    mock_task = _make_healthcheck_task(HealthcheckConfig(command="test -f /ready"))
+
+    with patch("pathlib.Path.exists", return_value=False):
+        result = harbor_to_compose_config(mock_task)
+
+    healthcheck = result.services["default"].healthcheck
+    assert healthcheck is not None
+    # Harbor's HealthcheckConfig defaults.
+    assert healthcheck.interval == "5s"
+    assert healthcheck.timeout == "30s"
+    assert healthcheck.start_period == "0s"
+    assert healthcheck.start_interval is None
+    assert healthcheck.retries == 3
+
+
+def test_healthcheck_fractional_seconds_render_as_whole_milliseconds():
+    """Fractional seconds become ``ms``: Inspect's duration parser is integer-only.
+
+    ``"1.5s"`` would parse as ``1s`` and ``"2.0s"`` as ``0s``, skewing the
+    ``compose up --wait`` timeout Inspect derives from the healthcheck.
+    """
+    mock_task = _make_healthcheck_task(
+        HealthcheckConfig(
+            command="test -f /ready",
+            interval_sec=1.5,
+            timeout_sec=0.25,
+            start_period_sec=2.0,
+            start_interval_sec=0.5,
+        )
+    )
+
+    with patch("pathlib.Path.exists", return_value=False):
+        result = harbor_to_compose_config(mock_task)
+
+    healthcheck = result.services["default"].healthcheck
+    assert healthcheck is not None
+    assert healthcheck.interval == "1500ms"
+    assert healthcheck.timeout == "250ms"
+    assert healthcheck.start_period == "2s"
+    assert healthcheck.start_interval == "500ms"
+
+
+def test_healthcheck_mapped_on_compose_yaml_default_service():
+    """A task.toml healthcheck reaches the default service of a task's own compose."""
+    mock_task = _make_healthcheck_task(HealthcheckConfig(command="test -f /ready"))
+    compose_yaml = """
+services:
+  main:
+    image: python:3.11
+    x-default: true
+  helper:
+    image: redis:7
+"""
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=compose_yaml)),
+    ):
+        mock_exists.side_effect = lambda: True
+        result = harbor_to_compose_config(mock_task)
+
+    healthcheck = result.services["main"].healthcheck
+    assert healthcheck is not None
+    assert healthcheck.test == ["CMD-SHELL", "test -f /ready"]
+    # Sidecars keep their own (absent) healthcheck.
+    assert result.services["helper"].healthcheck is None
+
+
+def test_healthcheck_does_not_overwrite_one_declared_in_compose_yaml():
+    """A compose-declared healthcheck wins, and the conflict is warned about."""
+    mock_task = _make_healthcheck_task(HealthcheckConfig(command="test -f /ready"))
+    compose_yaml = """
+services:
+  default:
+    image: python:3.11
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      retries: 7
+"""
+
+    with (
+        patch("pathlib.Path.exists") as mock_exists,
+        patch("builtins.open", mock_open(read_data=compose_yaml)),
+    ):
+        mock_exists.side_effect = lambda: True
+        with pytest.warns(UserWarning, match="healthcheck-task"):
+            result = harbor_to_compose_config(mock_task)
+
+    healthcheck = result.services["default"].healthcheck
+    assert healthcheck is not None
+    assert healthcheck.test == ["CMD", "pg_isready"]
+    assert healthcheck.retries == 7

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,10 +1,12 @@
 """Tests for Harbor task."""
 
+import warnings
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from harbor.models.task.config import HealthcheckConfig
 from harbor.models.task.task import Task as HarborTask
 from inspect_harbor._harbor.task import (
     _disambiguate_sample_ids,
@@ -236,6 +238,31 @@ def test_build_harbor_tasks_warns_on_allowlist_network_mode():
 
         with pytest.warns(UserWarning, match=r"allowlist.*\['allowlist-task'\]"):
             result = load_harbor_tasks(path="/some/allowlist/task")
+
+        assert len(result) == 1
+
+
+def test_build_harbor_tasks_does_not_warn_on_healthcheck():
+    """``[environment].healthcheck`` is wired into the compose service now.
+
+    It used to be reported as degraded fidelity; the converter maps it onto the
+    default service's healthcheck, so loading must be warning-free.
+    """
+    with (
+        patch("inspect_harbor._harbor.task._load_local_path") as mock_load_local,
+        patch("inspect_harbor._harbor.task.HarborTask") as mock_harbor_task,
+    ):
+        task_path = Path("/some/healthcheck/task")
+        mock_load_local.return_value = [task_path]
+        task_mock = _make_harbor_task_mock(name="healthcheck-task", task_dir=task_path)
+        task_mock.config.environment.healthcheck = HealthcheckConfig(
+            command="test -f /ready"
+        )
+        mock_harbor_task.return_value = task_mock
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = load_harbor_tasks(path="/some/healthcheck/task")
 
         assert len(result) == 1
 


### PR DESCRIPTION
`[environment].healthcheck` was flagged as degraded fidelity and dropped, so an agent
could start before the services it depends on were ready. Harbor's `HealthcheckConfig`
maps one-to-one onto Inspect's `ComposeHealthcheck` — `run_healthcheck` in
`harbor/environments/base.py` documents itself as mirroring Docker HEALTHCHECK semantics —
and Inspect's `compose_up` runs `up --detach --wait`, so the mapped healthcheck actually
gates readiness.

### Changes

- `converters.py`: `_harbor_healthcheck_to_compose()` maps `command` to a `CMD-SHELL`
  test and the `*_sec` fields to compose durations.
- Applied to the default service in **both** converter paths: the task-shipped
  `docker-compose.yaml` and the programmatic `ComposeService` build.
- A healthcheck already declared on the default service of the task's own compose wins —
  a service can only carry one, and the task's is the more specific declaration. The
  conflict warns.
- `start_interval` is omitted when `start_period_sec` is 0: it is inert outside the start
  period (in Docker and in Harbor's own loop) and needs Docker Engine 25+.
- `task.py`: healthcheck removed from the degraded-fidelity warning; `docs/tasks.qmd`
  updated.

### Duration rendering

Inspect's compose duration parser (`inspect_ai/util/_sandbox/docker/service.py`) matches
`(\d+)([a-z]+)`. Harbor's fields are floats, and `"5.0s"` parses as `0s` under that regex
(`5` isn't followed by a unit), which would skew the `up --wait` timeout. So durations are
rendered in whole units — `2.0` becomes `"2s"`, `1.5` becomes `"1500ms"`.

### Behaviour change to be aware of

Tasks declaring a healthcheck now fail at environment startup if it never passes, rather
than proceeding with a not-ready environment. That matches Harbor, which raises
`HealthcheckError`. Inspect also derives the `up --wait` timeout from
`retries * (interval + timeout)` when any service has a healthcheck; image build and pull
happen before `compose_up`, so this covers container start plus health polling only.

### Verification

- `make test` — 191 passed (184 before; 7 new).
- `make check` — ruff + `pyright` clean.
- New coverage in `tests/test_converters.py`: mapping in both paths, no-healthcheck case,
  Harbor defaults / inert `start_interval`, fractional-second rendering, and the
  compose-declares-its-own conflict. `tests/test_task.py` asserts loading a healthcheck
  task is now warning-free.
- Not run: a Docker smoke test against a live task with a delayed-ready service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
