### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -59,3 +59,16 @@
 # 6-task ale/rsi-post-training. Revisit if rsi-index becomes the canonical
 # home of the ALE RSI benchmark.
 - rsi-index/post-training
+# The Lamina "Headless Product Design skill" A/B experiment again (same
+# project already excluded as aryaniyaps/*): 12 samples = 4 toy apps x 3
+# arms (direct/plan/lamina) with dev-*-v3 scratch task ids. The lamina
+# GitHub org has 0 public repos and there is no paper or external
+# footprint. The tasks are also multi-step task.toml, which inspect_harbor
+# can't load (NotImplementedError). Revisit if Lamina publishes a real
+# benchmark repo/paper and multi-step tasks become supported.
+- lamina/*
+# Individual's (User, not org) dev pilot of the same Lamina experiment —
+# identical 12 task ids to lamina/product-bench, slug references a working
+# issue number ("lb6-dev-pilot-issue18"), and the desc itself says
+# "Development-only; not confirmatory". Not a published benchmark.
+- shiv-eshwar/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -502,6 +502,9 @@ harveyai/lab:
   repo: https://github.com/harveyai/harvey-labs
   title: Harvey LAB
 
+ibragim-badertdinov/swe-rebench-07-2026:
+  categories: []
+
 ineqmath/ineqmath:
   categories:
   - Mathematics
@@ -582,6 +585,9 @@ kumo/kumo-parity:
   desc: 'KUMO (parity split): subset of the KUMO procedural-reasoning benchmark used for parity / regression checks against the upstream evaluation.'
   function_name: kumo_parity
   title: KUMO (parity)
+
+lamina/product-bench:
+  categories: []
 
 lawbench/lawbench:
   categories:
@@ -844,6 +850,9 @@ scienceagentbench/scienceagentbench:
   desc: 'ScienceAgentBench: data-driven scientific discovery via Python programs across 4 disciplines.'
   function_name: scienceagentbench
   title: ScienceAgentBench
+
+shiv-eshwar/lb6-dev-pilot-issue18-rewardkit:
+  categories: []
 
 sierra-research/tau3-bench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -503,7 +503,11 @@ harveyai/lab:
   title: Harvey LAB
 
 ibragim-badertdinov/swe-rebench-07-2026:
-  categories: []
+  categories:
+  - Coding
+  title: SWE-rebench (July 2026)
+  repo: https://huggingface.co/datasets/nebius/SWE-rebench-leaderboard
+  arxiv: https://arxiv.org/abs/2505.20411
 
 ineqmath/ineqmath:
   categories:
@@ -585,9 +589,6 @@ kumo/kumo-parity:
   desc: 'KUMO (parity split): subset of the KUMO procedural-reasoning benchmark used for parity / regression checks against the upstream evaluation.'
   function_name: kumo_parity
   title: KUMO (parity)
-
-lamina/product-bench:
-  categories: []
 
 lawbench/lawbench:
   categories:
@@ -850,9 +851,6 @@ scienceagentbench/scienceagentbench:
   desc: 'ScienceAgentBench: data-driven scientific discovery via Python programs across 4 disciplines.'
   function_name: scienceagentbench
   title: ScienceAgentBench
-
-shiv-eshwar/lb6-dev-pilot-issue18-rewardkit:
-  categories: []
 
 sierra-research/tau3-bench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -508,6 +508,7 @@ ibragim-badertdinov/swe-rebench-07-2026:
   title: SWE-rebench (July 2026)
   repo: https://huggingface.co/datasets/nebius/SWE-rebench-leaderboard
   arxiv: https://arxiv.org/abs/2505.20411
+  function_name: swe_rebench_07_2026
 
 ineqmath/ineqmath:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -552,6 +552,8 @@
   task_function: ibragim_badertdinov_swe_rebench_07_2026
   samples: 111
   version: latest
+  categories:
+  - Coding
 - title: ineqmath/ineqmath
   path: registry/ineqmath.html
   desc: 'IneqMath: Olympiad-level inequality benchmark with expert-reviewed test problems, formulated as bound-estimation and relation-prediction subtasks with stepwise judging.'
@@ -647,13 +649,6 @@
   version: latest
   categories:
   - Reasoning
-- title: lamina/product-bench
-  path: registry/lamina_product_bench.html
-  desc: Product Bench — 3-arm public benchmark (direct / plan / lamina). Thin-slice greenfield product coding with a RewardKit LLM judge. Median of 3 full reruns using Cursor CLI + Composer 2.5.
-  desc_trunc: Product Bench — 3-arm public benchmark (direct / plan / lamina). Thin-slice greenfield product codi…
-  task_function: lamina_product_bench
-  samples: 12
-  version: latest
 - title: lawbench/lawbench
   path: registry/lawbench.html
   desc: 'LawBench: tasks evaluating LLMs on Chinese-law knowledge — legal entity recognition, reading comprehension, criminal-damage calculation, legal consulting — plus an abstention-rate metric.'
@@ -958,13 +953,6 @@
   - Science
   - Coding
   - Reasoning
-- title: shiv-eshwar/lb6-dev-pilot-issue18-rewardkit
-  path: registry/shiv_eshwar_lb6_dev_pilot_issue18_rewardkit.html
-  desc: Lamina Product Coding Pilot — 3-arm (direct / plan / lamina). Small product apps, LLM-judge on product code, median of 3 seeds. Development-only; not confirmatory LaminaBench-6.
-  desc_trunc: Lamina Product Coding Pilot — 3-arm (direct / plan / lamina). Small product apps, LLM-judge on prod…
-  task_function: shiv_eshwar_lb6_dev_pilot_issue18_rewardkit
-  samples: 12
-  version: latest
 - title: sierra-research/tau3-bench
   path: registry/sierra_research_tau3_bench.html
   desc: Third generation of τ-bench, extending the original with knowledge and voice. A simulation framework for evaluating customer service agents across airline, retail, telecom, and banking knowledge domains.

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -546,10 +546,10 @@
   - Law
   - Professional
 - title: ibragim-badertdinov/swe-rebench-07-2026
-  path: registry/ibragim_badertdinov_swe_rebench_07_2026.html
+  path: registry/swe_rebench_07_2026.html
   desc: 111 hard SWE-rebench leaderboard tasks from the July 2026 snapshot across Go, Java, Python, Rust, and TypeScript.
   desc_trunc: 111 hard SWE-rebench leaderboard tasks from the July 2026 snapshot across Go, Java, Python, Rust, a…
-  task_function: ibragim_badertdinov_swe_rebench_07_2026
+  task_function: swe_rebench_07_2026
   samples: 111
   version: latest
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -517,8 +517,8 @@
   - Coding
 - title: harbor-index/harbor-index
   path: registry/harbor_index.html
-  desc: 'Harbor Index: 80 agentic tasks spanning software engineering, science, and tool use (revision 1.3).'
-  desc_trunc: 'Harbor Index: 80 agentic tasks spanning software engineering, science, and tool use (revision 1.3).'
+  desc: 'Harbor Index: 80 agentic evaluation tasks spanning SWE, security, science, math, and optimization (revision 1.4).'
+  desc_trunc: 'Harbor Index: 80 agentic evaluation tasks spanning SWE, security, science, math, and optimization (…'
   task_function: harbor_index
   samples: 80
   version: latest
@@ -545,6 +545,13 @@
   categories:
   - Law
   - Professional
+- title: ibragim-badertdinov/swe-rebench-07-2026
+  path: registry/ibragim_badertdinov_swe_rebench_07_2026.html
+  desc: 111 hard SWE-rebench leaderboard tasks from the July 2026 snapshot across Go, Java, Python, Rust, and TypeScript.
+  desc_trunc: 111 hard SWE-rebench leaderboard tasks from the July 2026 snapshot across Go, Java, Python, Rust, a…
+  task_function: ibragim_badertdinov_swe_rebench_07_2026
+  samples: 111
+  version: latest
 - title: ineqmath/ineqmath
   path: registry/ineqmath.html
   desc: 'IneqMath: Olympiad-level inequality benchmark with expert-reviewed test problems, formulated as bound-estimation and relation-prediction subtasks with stepwise judging.'
@@ -640,6 +647,13 @@
   version: latest
   categories:
   - Reasoning
+- title: lamina/product-bench
+  path: registry/lamina_product_bench.html
+  desc: Product Bench — 3-arm public benchmark (direct / plan / lamina). Thin-slice greenfield product coding with a RewardKit LLM judge. Median of 3 full reruns using Cursor CLI + Composer 2.5.
+  desc_trunc: Product Bench — 3-arm public benchmark (direct / plan / lamina). Thin-slice greenfield product codi…
+  task_function: lamina_product_bench
+  samples: 12
+  version: latest
 - title: lawbench/lawbench
   path: registry/lawbench.html
   desc: 'LawBench: tasks evaluating LLMs on Chinese-law knowledge — legal entity recognition, reading comprehension, criminal-damage calculation, legal consulting — plus an abstention-rate metric.'
@@ -944,6 +958,13 @@
   - Science
   - Coding
   - Reasoning
+- title: shiv-eshwar/lb6-dev-pilot-issue18-rewardkit
+  path: registry/shiv_eshwar_lb6_dev_pilot_issue18_rewardkit.html
+  desc: Lamina Product Coding Pilot — 3-arm (direct / plan / lamina). Small product apps, LLM-judge on product code, median of 3 seeds. Development-only; not confirmatory LaminaBench-6.
+  desc_trunc: Lamina Product Coding Pilot — 3-arm (direct / plan / lamina). Small product apps, LLM-judge on prod…
+  task_function: shiv_eshwar_lb6_dev_pilot_issue18_rewardkit
+  samples: 12
+  version: latest
 - title: sierra-research/tau3-bench
   path: registry/sierra_research_tau3_bench.html
   desc: Third generation of τ-bench, extending the original with knowledge and voice. A simulation framework for evaluating customer service agents across airline, retail, telecom, and banking knowledge domains.

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2090,37 +2090,6 @@ def kumo_parity(
 
 
 @task
-def lamina_product_bench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Product Bench — 3-arm public benchmark (direct / plan / lamina). Thin-slice greenfield product coding with a RewardKit LLM judge. Median of 3 full reruns using Cursor CLI + Composer 2.5.
-
-    Slug: lamina/product-bench
-    Latest digest: sha256:e95382c6f1f9f605cfd451838696a762b3a382c194135911338be4a1c70757aa
-    """
-    return _harbor_base(
-        package_name="lamina/product-bench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def lawbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3106,37 +3075,6 @@ def scienceagentbench(
     """
     return _harbor_base(
         package_name="scienceagentbench/scienceagentbench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def shiv_eshwar_lb6_dev_pilot_issue18_rewardkit(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Lamina Product Coding Pilot — 3-arm (direct / plan / lamina). Small product apps, LLM-judge on product code, median of 3 seeds. Development-only; not confirmatory LaminaBench-6.
-
-    Slug: shiv-eshwar/lb6-dev-pilot-issue18-rewardkit
-    Latest digest: sha256:8da16c9f65faf6038931e6f11c0314ec3a80ce0b05c38cf48ec8e9e2ec13d622
-    """
-    return _harbor_base(
-        package_name="shiv-eshwar/lb6-dev-pilot-issue18-rewardkit",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1667,10 +1667,10 @@ def harbor_index(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""Harbor Index: 80 agentic tasks spanning software engineering, science, and tool use (revision 1.3).
+    r"""Harbor Index: 80 agentic evaluation tasks spanning SWE, security, science, math, and optimization (revision 1.4).
 
     Slug: harbor-index/harbor-index
-    Latest digest: sha256:fdb3554453d29f96bfe87ddf36e6770f6ceadd375e8189c62718ef2f215bbbad
+    Latest digest: sha256:74af9ee31f50d8dac213e67ebaeeddc6bb0e4470a28968f84766916e09fe13dd
     """
     return _harbor_base(
         package_name="harbor-index/harbor-index",
@@ -1736,6 +1736,37 @@ def harveyai_lab(
     """
     return _harbor_base(
         package_name="harveyai/lab",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def ibragim_badertdinov_swe_rebench_07_2026(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""111 hard SWE-rebench leaderboard tasks from the July 2026 snapshot across Go, Java, Python, Rust, and TypeScript
+
+    Slug: ibragim-badertdinov/swe-rebench-07-2026
+    Latest digest: sha256:e2e357045bf03e4900d2506c36562f6eaff7acd37f63780600967ea3aecdcd79
+    """
+    return _harbor_base(
+        package_name="ibragim-badertdinov/swe-rebench-07-2026",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -2046,6 +2077,37 @@ def kumo_parity(
     """
     return _harbor_base(
         package_name="kumo/kumo-parity",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def lamina_product_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Product Bench — 3-arm public benchmark (direct / plan / lamina). Thin-slice greenfield product coding with a RewardKit LLM judge. Median of 3 full reruns using Cursor CLI + Composer 2.5.
+
+    Slug: lamina/product-bench
+    Latest digest: sha256:e95382c6f1f9f605cfd451838696a762b3a382c194135911338be4a1c70757aa
+    """
+    return _harbor_base(
+        package_name="lamina/product-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -2823,7 +2885,7 @@ def rounakbende10_rh_swe_bench(
     r"""Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos
 
     Slug: rounakbende10/rh-swe-bench
-    Latest digest: sha256:35fa496a85a348f06ee47ef69e8899c573ecceb0a1d3c5102482928492267667
+    Latest digest: sha256:4e73020a541ceb977c9a79658fb8cc95a03d055c51fce0788c4141882b8bfffe
     """
     return _harbor_base(
         package_name="rounakbende10/rh-swe-bench",
@@ -3044,6 +3106,37 @@ def scienceagentbench(
     """
     return _harbor_base(
         package_name="scienceagentbench/scienceagentbench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def shiv_eshwar_lb6_dev_pilot_issue18_rewardkit(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Lamina Product Coding Pilot — 3-arm (direct / plan / lamina). Small product apps, LLM-judge on product code, median of 3 seeds. Development-only; not confirmatory LaminaBench-6.
+
+    Slug: shiv-eshwar/lb6-dev-pilot-issue18-rewardkit
+    Latest digest: sha256:8da16c9f65faf6038931e6f11c0314ec3a80ce0b05c38cf48ec8e9e2ec13d622
+    """
+    return _harbor_base(
+        package_name="shiv-eshwar/lb6-dev-pilot-issue18-rewardkit",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -1749,7 +1749,7 @@ def harveyai_lab(
 
 
 @task
-def ibragim_badertdinov_swe_rebench_07_2026(
+def swe_rebench_07_2026(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
ibragim-badertdinov/swe-rebench-07-2026
lamina/product-bench
shiv-eshwar/lb6-dev-pilot-issue18-rewardkit
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks