### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/datasets.qmd
+++ b/docs/datasets.qmd
@@ -47,6 +47,7 @@ These are upstream issues we've encountered while integrating Harbor datasets. E
 | Dataset | Issue | Status |
 |---------|-------|--------|
 | `xlang/ds-1000` | Multiple configuration issues preventing execution (`pull access denied for ds1000`) | [harbor-datasets#103](https://github.com/laude-institute/harbor-datasets/issues/103) |
+| `cohere/terminal_bench_aai` | `cohere_terminal_bench_aai()` raises a `ValidationError` at construction: two tasks (`install-windows-3.11`, `install-windows-xp`) use compose keys (`restart`, `stdin_open`, `tty`) that inspect-ai doesn't accept yet, and one bad task blocks the whole function | [inspect_ai#4727](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4727) |
 
 ## Volume mount limitations
 

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -236,6 +236,9 @@ atm-bench/atm-bench-hard-sgm:
   function_name: atm_bench_hard_sgm
   title: ATM-Bench-Hard (SGM)
 
+bencalvert04/programbench:
+  categories: []
+
 benchflow/skillsbench:
   categories:
   - Assistants
@@ -300,6 +303,9 @@ codepde/codepde:
   desc: 'CodePDE: framing partial-differential-equation solving as a code-generation task to benchmark LLMs on producing correct, efficient PDE solvers.'
   function_name: codepde
   title: CodePDE
+
+cohere/terminal_bench_aai:
+  categories: []
 
 crustbench/crustbench:
   categories:
@@ -880,6 +886,9 @@ snorkel-ai/senior-swe-bench-v2026.06:
   title: Senior SWE-Bench (v2026.06)
   repo: https://github.com/snorkel-ai/senior-swe-bench-v2026.06
   desc: 'Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).'
+
+snowflake-labs/dbt-bench:
+  categories: []
 
 stanford/medagentbench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -237,7 +237,11 @@ atm-bench/atm-bench-hard-sgm:
   title: ATM-Bench-Hard (SGM)
 
 bencalvert04/programbench:
-  categories: []
+  categories:
+  - Coding
+  arxiv: https://arxiv.org/abs/2605.03546
+  repo: https://github.com/facebookresearch/ProgramBench
+  title: ProgramBench
 
 benchflow/skillsbench:
   categories:
@@ -305,7 +309,12 @@ codepde/codepde:
   title: CodePDE
 
 cohere/terminal_bench_aai:
-  categories: []
+  categories:
+  - Coding
+  - Assistants
+  arxiv: https://arxiv.org/abs/2601.11868
+  repo: https://github.com/harbor-framework/terminal-bench
+  title: Terminal-Bench Hard
 
 crustbench/crustbench:
   categories:
@@ -888,7 +897,10 @@ snorkel-ai/senior-swe-bench-v2026.06:
   desc: 'Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).'
 
 snowflake-labs/dbt-bench:
-  categories: []
+  categories:
+  - Coding
+  repo: https://github.com/Snowflake-Labs/dbt-bench
+  title: dbt-bench
 
 stanford/medagentbench:
   categories:
@@ -975,7 +987,7 @@ terminal-bench/terminal-bench-2:
   - Coding
   - Assistants
   arxiv: https://arxiv.org/abs/2601.11868
-  repo: https://github.com/laude-institute/terminal-bench
+  repo: https://github.com/harbor-framework/terminal-bench
   desc: 'Terminal-Bench v2: benchmark for testing AI agents in real terminal environments — from compiling code to training models and setting up servers.'
   function_name: terminal_bench_2
   title: Terminal-Bench v2
@@ -985,7 +997,7 @@ terminal-bench/terminal-bench-2-1:
   - Coding
   - Assistants
   arxiv: https://arxiv.org/abs/2601.11868
-  repo: https://github.com/laude-institute/terminal-bench
+  repo: https://github.com/harbor-framework/terminal-bench
   desc: 'Terminal-Bench v2.1 (point release of v2): benchmark for testing AI agents in real terminal environments — from compiling code to training models and setting up servers.'
   function_name: terminal_bench_2_1
   title: Terminal-Bench v2.1

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -235,6 +235,8 @@
   task_function: bencalvert04_programbench
   samples: 200
   version: latest
+  categories:
+  - Coding
 - title: benchflow/skillsbench
   path: registry/benchflow_skillsbench.html
   desc: 'SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folders of instructions, scripts, and resources) to complete specialized workflows spanning science, engineering, and professional domains.'
@@ -317,6 +319,9 @@
   task_function: cohere_terminal_bench_aai
   samples: 44
   version: latest
+  categories:
+  - Coding
+  - Assistants
 - title: crustbench/crustbench
   path: registry/crustbench.html
   desc: 'CRUST-Bench: real-world C repositories paired with hand-written safe-Rust interfaces and tests, benchmarking LLMs on C-to-safe-Rust transpilation.'
@@ -1005,6 +1010,8 @@
   task_function: snowflake_labs_dbt_bench
   samples: 103
   version: latest
+  categories:
+  - Coding
 - title: stanford/medagentbench
   path: registry/stanford_medagentbench.html
   desc: 'MedAgentBench: clinically-relevant tasks across 10 categories in a FHIR-compliant virtual EHR, benchmarking LLM agents on medical decision-making, planning, and execution.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -228,6 +228,13 @@
   categories:
   - Assistants
   - Reasoning
+- title: bencalvert04/programbench
+  path: registry/bencalvert04_programbench.html
+  desc: 'ProgramBench cleanroom reconstruction tasks: reimplementing real-world CLI tools from popular open-source repos.'
+  desc_trunc: 'ProgramBench cleanroom reconstruction tasks: reimplementing real-world CLI tools from popular open-…'
+  task_function: bencalvert04_programbench
+  samples: 200
+  version: latest
 - title: benchflow/skillsbench
   path: registry/benchflow_skillsbench.html
   desc: 'SkillsBench: agent benchmark measuring how effectively models compose and use modular skills (folders of instructions, scripts, and resources) to complete specialized workflows spanning science, engineering, and professional domains.'
@@ -303,6 +310,13 @@
   - Science
   - Physics
   - Coding
+- title: cohere/terminal_bench_aai
+  path: registry/cohere_terminal_bench_aai.html
+  desc: 'AAII Terminal-Bench Hard: 44 hard tasks from terminal-bench v1 (terminal-bench-core==0.1.1), used with the Terminus-2 agent.'
+  desc_trunc: 'AAII Terminal-Bench Hard: 44 hard tasks from terminal-bench v1 (terminal-bench-core==0.1.1), used w…'
+  task_function: cohere_terminal_bench_aai
+  samples: 44
+  version: latest
 - title: crustbench/crustbench
   path: registry/crustbench.html
   desc: 'CRUST-Bench: real-world C repositories paired with hand-written safe-Rust interfaces and tests, benchmarking LLMs on C-to-safe-Rust transpilation.'
@@ -984,6 +998,13 @@
   version: latest
   categories:
   - Coding
+- title: snowflake-labs/dbt-bench
+  path: registry/snowflake_labs_dbt_bench.html
+  desc: 'Agentic dbt data-engineering benchmark: 103 real-world dbt tasks (analytics, dimensional modeling, incremental models, bug-fixes, snapshots) runnable hermetically on DuckDB or against Snowflake via DB_TYPE. A 30-task balanced fast subset for cost-bounded / CI runs is listed in configs/fast-30.txt.'
+  desc_trunc: 'Agentic dbt data-engineering benchmark: 103 real-world dbt tasks (analytics, dimensional modeling,…'
+  task_function: snowflake_labs_dbt_bench
+  samples: 103
+  version: latest
 - title: stanford/medagentbench
   path: registry/stanford_medagentbench.html
   desc: 'MedAgentBench: clinically-relevant tasks across 10 categories in a FHIR-compliant virtual EHR, benchmarking LLM agents on medical decision-making, planning, and execution.'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 # Note: harbor package requires Python >=3.12, so we cannot lower this requirement
 requires-python = ">=3.12"
 license = { text = "MIT License" }
-dependencies = ["inspect-ai>=0.3.225", "harbor>=0.17.1,<0.18", "pyyaml"]
+dependencies = ["inspect-ai>=0.3.236", "harbor>=0.17.1,<0.18", "pyyaml"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -306,7 +306,7 @@ def abundant_swe_marathon(
     r"""Ultra long-horizon software engineering tasks from SWE-Marathon.
 
     Slug: abundant/swe-marathon
-    Latest digest: sha256:862b01dc3c8d3bf5b8016ea68181c3963d62588ab03b928e5c6646cfce4e7b3f
+    Latest digest: sha256:9b351bf9bd305e6fd8bfdba9120e42551d027bf173b81ea790e8df2f21d7a624
     """
     return _harbor_base(
         package_name="abundant/swe-marathon",
@@ -726,6 +726,37 @@ def atm_bench_hard_sgm(
 
 
 @task
+def bencalvert04_programbench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""ProgramBench cleanroom reconstruction tasks: reimplementing real-world CLI tools from popular open-source repos.
+
+    Slug: bencalvert04/programbench
+    Latest digest: sha256:753a712740549277584134c44e36934ab135463b7b51e243390ce304f5dda5da
+    """
+    return _harbor_base(
+        package_name="bencalvert04/programbench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def benchflow_skillsbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -961,6 +992,37 @@ def codepde(
     """
     return _harbor_base(
         package_name="codepde/codepde",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def cohere_terminal_bench_aai(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""AAII Terminal-Bench Hard: 44 hard tasks from terminal-bench v1 (terminal-bench-core==0.1.1), used with the Terminus-2 agent.
+
+    Slug: cohere/terminal_bench_aai
+    Latest digest: sha256:d8908945101bb9a713690ac46539d13ca7d44658637f2650a857470926c191b9
+    """
+    return _harbor_base(
+        package_name="cohere/terminal_bench_aai",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -2854,7 +2916,7 @@ def rounakbende10_rh_swe_bench(
     r"""Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos
 
     Slug: rounakbende10/rh-swe-bench
-    Latest digest: sha256:4e73020a541ceb977c9a79658fb8cc95a03d055c51fce0788c4141882b8bfffe
+    Latest digest: sha256:2912e953dd598963a5e7bb54f5fa6524baac1a073f1debd2bf1d6e1fad990d66
     """
     return _harbor_base(
         package_name="rounakbende10/rh-swe-bench",
@@ -3168,6 +3230,37 @@ def snorkel_ai_senior_swe_bench_v2026_06(
     """
     return _harbor_base(
         package_name="snorkel-ai/senior-swe-bench-v2026.06",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def snowflake_labs_dbt_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Agentic dbt data-engineering benchmark: 103 real-world dbt tasks (analytics, dimensional modeling, incremental models, bug-fixes, snapshots) runnable hermetically on DuckDB or against Snowflake via DB_TYPE. A 30-task balanced fast subset for cost-bounded / CI runs is listed in configs/fast-30.txt.
+
+    Slug: snowflake-labs/dbt-bench
+    Latest digest: sha256:4b5932ee20c4b0b5a0241b5b184c1d9d8e9658bda0d1cb2389e8e941046e8e0a
+    """
+    return _harbor_base(
+        package_name="snowflake-labs/dbt-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-harbor = "2026-07-05T00:00:00Z"
+harbor = "2026-07-04T23:00:00Z"
 inspect-ai = false
 
 [[package]]
@@ -211,15 +211,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -1281,7 +1281,7 @@ wheels = [
 
 [[package]]
 name = "inspect-ai"
-version = "0.3.234"
+version = "0.3.251"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1324,9 +1324,9 @@ dependencies = [
     { name = "zipp" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/ee/dd3f75d12b7dc54aab1493b8f06ec35e5c03981eed0857cc44deb89b909a/inspect_ai-0.3.234.tar.gz", hash = "sha256:a5cb12b06b7ad5d1b99a304d58a8ca6e756555f4ff4aafc101594f9ea4c49f3a", size = 46963453, upload-time = "2026-06-02T19:48:21.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/31/e1c5ae271f7ceac8446f6a39bdf916d76fa024ec63b7febe0d22b94061f1/inspect_ai-0.3.251.tar.gz", hash = "sha256:0dc938ac5ea816ce3bacd112def02840952161f82fca02c49425eefb5bef5772", size = 50175614, upload-time = "2026-07-29T15:02:51.489Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/c6/ca8ce4a3a8dedf60c63bcc4b0a561a3e874f5a271f56a7e36968e5176ffc/inspect_ai-0.3.234-py3-none-any.whl", hash = "sha256:8265e077e9b924636fcc8a2e15d059302668555c8cb8deb2a14a85ec3e279724", size = 36436637, upload-time = "2026-06-02T19:48:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/61/65/d78c2c921ce457fcca76425b7a401337dda0456bada0bcaf7c21be3badbd/inspect_ai-0.3.251-py3-none-any.whl", hash = "sha256:6f18df2f14dd0646db78eaffe0db6d7735334450fdd4e03ec8f45b42a669b0fe", size = 37585651, upload-time = "2026-07-29T15:02:38.447Z" },
 ]
 
 [[package]]
@@ -1366,7 +1366,7 @@ doc = [
 [package.metadata]
 requires-dist = [
     { name = "harbor", specifier = ">=0.17.1,<0.18" },
-    { name = "inspect-ai", specifier = ">=0.3.225" },
+    { name = "inspect-ai", specifier = ">=0.3.236" },
     { name = "pyyaml" },
 ]
 
@@ -2478,7 +2478,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4157,7 +4157,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information
- fix: require inspect-ai >=0.3.236 (compose `tmpfs`/`platform` support needed by `cohere/terminal_bench_aai`)
- docs: known-issues entry for `cohere/terminal_bench_aai` (two tasks blocked on UKGovernmentBEIS/inspect_ai#4727)

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks
