### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -72,3 +72,12 @@
 # issue number ("lb6-dev-pilot-issue18"), and the desc itself says
 # "Development-only; not confirmatory". Not a published benchmark.
 - shiv-eshwar/*
+# Individual's (User, not org) 2-sample compute-markets experiment matching
+# their "the-compute-bazaar" repo ("tinkering with compute markets"); no
+# benchmark repo, paper, or external footprint. Not a published benchmark.
+- gustofied/*
+# Individual's (User, not org) Kubernetes-sandbox ports of benchmarks we
+# already list canonically (arc-agi-2-k8s → arcprize/arc-agi-2, dbt-labs-k8s
+# → dbt-labs/ade-bench); the descs say "adapted for Kubernetes sandbox
+# execution". Derivative infra re-uploads, not new benchmarks.
+- titouanlne/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -800,7 +800,10 @@ reasoning-gym/reasoning-gym-hard:
   title: Reasoning Gym (hard)
 
 red-hat-ai/haiku-hard:
-  categories: []
+  categories:
+  - Coding
+  desc: Hard subset of SWE-style Go bug-fixing tasks drawn from Red Hat-ecosystem repos (openshift, operator-framework, coreos) — 177 instances filtered to those Claude Haiku failed to solve.
+  title: Haiku-Hard
 
 replicationbench/replicationbench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -496,6 +496,9 @@ grandsmile/unicode:
   desc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.'
   title: UniCode
 
+gustofied/compute-bazaar-bench:
+  categories: []
+
 harbor-index/harbor-index:
   categories:
   - Assistants
@@ -722,6 +725,9 @@ openai/swe-lancer-diamond-manager:
   desc: 'A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.'
   title: SWE-Lancer Diamond (Manager)
 
+orca-bench/orca-bench:
+  categories: []
+
 orinlabs/horizon-public:
   categories:
   - Assistants
@@ -788,6 +794,9 @@ reasoning-gym/reasoning-gym-hard:
   desc: 'Reasoning Gym (hard split): procedurally-generated, algorithmically-verifiable reasoning tasks at harder difficulty across 90+ task families.'
   function_name: reasoning_gym_hard
   title: Reasoning Gym (hard)
+
+red-hat-ai/haiku-hard:
+  categories: []
 
 replicationbench/replicationbench:
   categories:
@@ -896,11 +905,8 @@ snorkel-ai/senior-swe-bench-v2026.06:
   repo: https://github.com/snorkel-ai/senior-swe-bench-v2026.06
   desc: 'Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).'
 
-snowflake-labs/dbt-bench:
-  categories:
-  - Coding
-  repo: https://github.com/Snowflake-Labs/dbt-bench
-  title: dbt-bench
+snowflake-labs/data-eng-bench:
+  categories: []
 
 stanford/medagentbench:
   categories:
@@ -1032,6 +1038,12 @@ tinycomputerai/bun-server-bench:
   categories:
   - Coding
   repo: https://github.com/tinycomputerai/bun-server-bench
+
+titouanlne/arc-agi-2-k8s:
+  categories: []
+
+titouanlne/dbt-labs-k8s:
+  categories: []
 
 usaco/usaco:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -496,9 +496,6 @@ grandsmile/unicode:
   desc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.'
   title: UniCode
 
-gustofied/compute-bazaar-bench:
-  categories: []
-
 harbor-index/harbor-index:
   categories:
   - Assistants
@@ -726,7 +723,14 @@ openai/swe-lancer-diamond-manager:
   title: SWE-Lancer Diamond (Manager)
 
 orca-bench/orca-bench:
-  categories: []
+  categories:
+  - Coding
+  - Professional
+  function_name: orca_bench
+  repo: https://github.com/orca-bench/ORCA-bench
+  arxiv: https://arxiv.org/abs/2607.28545
+  desc: 'ORCA-bench: root-cause analysis of oncall incidents — agents investigate telemetry from an instrumented microservices system to diagnose each incident; public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard).'
+  title: ORCA-bench
 
 orinlabs/horizon-public:
   categories:
@@ -906,7 +910,9 @@ snorkel-ai/senior-swe-bench-v2026.06:
   desc: 'Senior SWE-Bench: senior-engineer coding tasks drawn from real pull requests in production repositories — building features from PM-style instructions and investigating bugs from runtime evidence, judged for correctness and code taste (50-task public split).'
 
 snowflake-labs/data-eng-bench:
-  categories: []
+  categories:
+  - Coding
+  repo: https://github.com/Snowflake-Labs/data-eng-bench
 
 stanford/medagentbench:
   categories:
@@ -1038,12 +1044,6 @@ tinycomputerai/bun-server-bench:
   categories:
   - Coding
   repo: https://github.com/tinycomputerai/bun-server-bench
-
-titouanlne/arc-agi-2-k8s:
-  categories: []
-
-titouanlne/dbt-labs-k8s:
-  categories: []
 
 usaco/usaco:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -889,11 +889,13 @@
   - Reasoning
 - title: red-hat-ai/haiku-hard
   path: registry/red_hat_ai_haiku_hard.html
-  desc: 178 Go instances that Claude Haiku failed to solve.
-  desc_trunc: 178 Go instances that Claude Haiku failed to solve.
+  desc: Hard subset of SWE-style Go bug-fixing tasks drawn from Red Hat-ecosystem repos (openshift, operator-framework, coreos) — 177 instances filtered to those Claude Haiku failed to solve.
+  desc_trunc: Hard subset of SWE-style Go bug-fixing tasks drawn from Red Hat-ecosystem repos (openshift, operato…
   task_function: red_hat_ai_haiku_hard
   samples: 177
   version: latest
+  categories:
+  - Coding
 - title: replicationbench/replicationbench
   path: registry/replicationbench.html
   desc: 'ReplicationBench: end-to-end replication of astrophysics research papers — agents reproduce implementation, methodology, and core findings of expert-validated papers, scored on result accuracy.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -534,6 +534,13 @@
   version: latest
   categories:
   - Coding
+- title: gustofied/compute-bazaar-bench
+  path: registry/gustofied_compute_bazaar_bench.html
+  desc: Task-based evaluations for agents working in compute markets.
+  desc_trunc: Task-based evaluations for agents working in compute markets.
+  task_function: gustofied_compute_bazaar_bench
+  samples: 2
+  version: latest
 - title: harbor-index/harbor-index
   path: registry/harbor_index.html
   desc: 'Harbor Index: 80 agentic evaluation tasks spanning SWE, security, science, math, and optimization (revision 1.4).'
@@ -803,6 +810,13 @@
   categories:
   - Coding
   - Professional
+- title: orca-bench/orca-bench
+  path: registry/orca_bench_orca_bench.html
+  desc: An agent benchmark for root cause analysis — public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard). For the results on all 1,079 tasks, please see.
+  desc_trunc: An agent benchmark for root cause analysis — public split of 755 tasks across 77 incidents (245 eas…
+  task_function: orca_bench_orca_bench
+  samples: 755
+  version: latest
 - title: orinlabs/horizon-public
   path: registry/orinlabs_horizon_public.html
   desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'
@@ -877,6 +891,13 @@
   version: latest
   categories:
   - Reasoning
+- title: red-hat-ai/haiku-hard
+  path: registry/red_hat_ai_haiku_hard.html
+  desc: 178 Go instances that Claude Haiku failed to solve.
+  desc_trunc: 178 Go instances that Claude Haiku failed to solve.
+  task_function: red_hat_ai_haiku_hard
+  samples: 177
+  version: latest
 - title: replicationbench/replicationbench
   path: registry/replicationbench.html
   desc: 'ReplicationBench: end-to-end replication of astrophysics research papers — agents reproduce implementation, methodology, and core findings of expert-validated papers, scored on result accuracy.'
@@ -1003,15 +1024,13 @@
   version: latest
   categories:
   - Coding
-- title: snowflake-labs/dbt-bench
-  path: registry/snowflake_labs_dbt_bench.html
+- title: snowflake-labs/data-eng-bench
+  path: registry/snowflake_labs_data_eng_bench.html
   desc: 'Agentic dbt data-engineering benchmark: 103 real-world dbt tasks (analytics, dimensional modeling, incremental models, bug-fixes, snapshots) runnable hermetically on DuckDB or against Snowflake via DB_TYPE. A 30-task balanced fast subset for cost-bounded / CI runs is listed in configs/fast-30.txt.'
   desc_trunc: 'Agentic dbt data-engineering benchmark: 103 real-world dbt tasks (analytics, dimensional modeling,…'
-  task_function: snowflake_labs_dbt_bench
+  task_function: snowflake_labs_data_eng_bench
   samples: 103
   version: latest
-  categories:
-  - Coding
 - title: stanford/medagentbench
   path: registry/stanford_medagentbench.html
   desc: 'MedAgentBench: clinically-relevant tasks across 10 categories in a FHIR-compliant virtual EHR, benchmarking LLM agents on medical decision-making, planning, and execution.'
@@ -1155,6 +1174,20 @@
   version: latest
   categories:
   - Coding
+- title: titouanlne/arc-agi-2-k8s
+  path: registry/titouanlne_arc_agi_2_k8s.html
+  desc: ARC-AGI-2 tasks adapted for Kubernetes sandbox execution via a shared pre-built Docker Hub image.
+  desc_trunc: ARC-AGI-2 tasks adapted for Kubernetes sandbox execution via a shared pre-built Docker Hub image.
+  task_function: titouanlne_arc_agi_2_k8s
+  samples: 167
+  version: latest
+- title: titouanlne/dbt-labs-k8s
+  path: registry/titouanlne_dbt_labs_k8s.html
+  desc: dbt-labs ADE-bench tasks adapted for Kubernetes sandbox execution via pre-built Docker Hub images.
+  desc_trunc: dbt-labs ADE-bench tasks adapted for Kubernetes sandbox execution via pre-built Docker Hub images.
+  task_function: titouanlne_dbt_labs_k8s
+  samples: 48
+  version: latest
 - title: usaco/usaco
   path: registry/usaco.html
   desc: 'USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -534,13 +534,6 @@
   version: latest
   categories:
   - Coding
-- title: gustofied/compute-bazaar-bench
-  path: registry/gustofied_compute_bazaar_bench.html
-  desc: Task-based evaluations for agents working in compute markets.
-  desc_trunc: Task-based evaluations for agents working in compute markets.
-  task_function: gustofied_compute_bazaar_bench
-  samples: 2
-  version: latest
 - title: harbor-index/harbor-index
   path: registry/harbor_index.html
   desc: 'Harbor Index: 80 agentic evaluation tasks spanning SWE, security, science, math, and optimization (revision 1.4).'
@@ -811,12 +804,15 @@
   - Coding
   - Professional
 - title: orca-bench/orca-bench
-  path: registry/orca_bench_orca_bench.html
-  desc: An agent benchmark for root cause analysis — public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard). For the results on all 1,079 tasks, please see.
-  desc_trunc: An agent benchmark for root cause analysis — public split of 755 tasks across 77 incidents (245 eas…
-  task_function: orca_bench_orca_bench
+  path: registry/orca_bench.html
+  desc: 'ORCA-bench: root-cause analysis of oncall incidents — agents investigate telemetry from an instrumented microservices system to diagnose each incident; public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard).'
+  desc_trunc: 'ORCA-bench: root-cause analysis of oncall incidents — agents investigate telemetry from an instrume…'
+  task_function: orca_bench
   samples: 755
   version: latest
+  categories:
+  - Coding
+  - Professional
 - title: orinlabs/horizon-public
   path: registry/orinlabs_horizon_public.html
   desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'
@@ -1031,6 +1027,8 @@
   task_function: snowflake_labs_data_eng_bench
   samples: 103
   version: latest
+  categories:
+  - Coding
 - title: stanford/medagentbench
   path: registry/stanford_medagentbench.html
   desc: 'MedAgentBench: clinically-relevant tasks across 10 categories in a FHIR-compliant virtual EHR, benchmarking LLM agents on medical decision-making, planning, and execution.'
@@ -1174,20 +1172,6 @@
   version: latest
   categories:
   - Coding
-- title: titouanlne/arc-agi-2-k8s
-  path: registry/titouanlne_arc_agi_2_k8s.html
-  desc: ARC-AGI-2 tasks adapted for Kubernetes sandbox execution via a shared pre-built Docker Hub image.
-  desc_trunc: ARC-AGI-2 tasks adapted for Kubernetes sandbox execution via a shared pre-built Docker Hub image.
-  task_function: titouanlne_arc_agi_2_k8s
-  samples: 167
-  version: latest
-- title: titouanlne/dbt-labs-k8s
-  path: registry/titouanlne_dbt_labs_k8s.html
-  desc: dbt-labs ADE-bench tasks adapted for Kubernetes sandbox execution via pre-built Docker Hub images.
-  desc_trunc: dbt-labs ADE-bench tasks adapted for Kubernetes sandbox execution via pre-built Docker Hub images.
-  task_function: titouanlne_dbt_labs_k8s
-  samples: 48
-  version: latest
 - title: usaco/usaco
   path: registry/usaco.html
   desc: 'USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -430,7 +430,7 @@ def agentscope_ai_pawbench(
     r"""PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.
 
     Slug: agentscope-ai/pawbench
-    Latest digest: sha256:a4197a2fe40bf045abad4ea2ab1037bf9c8bdfab01c378fdcc2b40242f5d63dd
+    Latest digest: sha256:d2849f918a072575eeee13c79818c727f87776dac8bdc8d9c1ec084bc6bcab56
     """
     return _harbor_base(
         package_name="agentscope-ai/pawbench",
@@ -1718,6 +1718,37 @@ def grandsmile_unicode(
 
 
 @task
+def gustofied_compute_bazaar_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Task-based evaluations for agents working in compute markets.
+
+    Slug: gustofied/compute-bazaar-bench
+    Latest digest: sha256:cd42c9b34b8b14b6298e87fb7bd477cd7401b9ed3ff5235bfbedcceb2a7642a1
+    """
+    return _harbor_base(
+        package_name="gustofied/compute-bazaar-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def harbor_index(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2586,6 +2617,37 @@ def openai_swe_lancer_diamond_manager(
 
 
 @task
+def orca_bench_orca_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""An agent benchmark for root cause analysis — public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard). For the results on all 1,079 tasks, please see https://arxiv.org/abs/2607.28545.
+
+    Slug: orca-bench/orca-bench
+    Latest digest: sha256:1ef729757d4974ffe4e835d541c601f957975edf8c93ef02eec97e26d3069b93
+    """
+    return _harbor_base(
+        package_name="orca-bench/orca-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def orinlabs_horizon_public(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2821,6 +2883,37 @@ def reasoning_gym_hard(
     """
     return _harbor_base(
         package_name="reasoning-gym/reasoning-gym-hard",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def red_hat_ai_haiku_hard(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""178 Go instances that Claude Haiku failed to solve
+
+    Slug: red-hat-ai/haiku-hard
+    Latest digest: sha256:b24383f875f3d1ecad10aa8e8249d40fdb594fffffa3c842cf2cb0d96325a4e6
+    """
+    return _harbor_base(
+        package_name="red-hat-ai/haiku-hard",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -3243,7 +3336,7 @@ def snorkel_ai_senior_swe_bench_v2026_06(
 
 
 @task
-def snowflake_labs_dbt_bench(
+def snowflake_labs_data_eng_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -3256,11 +3349,11 @@ def snowflake_labs_dbt_bench(
 ) -> Task:
     r"""Agentic dbt data-engineering benchmark: 103 real-world dbt tasks (analytics, dimensional modeling, incremental models, bug-fixes, snapshots) runnable hermetically on DuckDB or against Snowflake via DB_TYPE. A 30-task balanced fast subset for cost-bounded / CI runs is listed in configs/fast-30.txt.
 
-    Slug: snowflake-labs/dbt-bench
-    Latest digest: sha256:4b5932ee20c4b0b5a0241b5b184c1d9d8e9658bda0d1cb2389e8e941046e8e0a
+    Slug: snowflake-labs/data-eng-bench
+    Latest digest: sha256:de31878dba7e5a9aad85dc8276820b0a20ab593aed46ff93dfbbbdb6007ec995
     """
     return _harbor_base(
-        package_name="snowflake-labs/dbt-bench",
+        package_name="snowflake-labs/data-eng-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -3726,6 +3819,68 @@ def tinycomputerai_bun_server_bench(
     """
     return _harbor_base(
         package_name="tinycomputerai/bun-server-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def titouanlne_arc_agi_2_k8s(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""ARC-AGI-2 tasks adapted for Kubernetes sandbox execution via a shared pre-built Docker Hub image
+
+    Slug: titouanlne/arc-agi-2-k8s
+    Latest digest: sha256:bf2b0e28459d5354635332ade9fb3eee64ed6dd06eba06437e62716c3e94a86b
+    """
+    return _harbor_base(
+        package_name="titouanlne/arc-agi-2-k8s",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def titouanlne_dbt_labs_k8s(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""dbt-labs ADE-bench tasks adapted for Kubernetes sandbox execution via pre-built Docker Hub images
+
+    Slug: titouanlne/dbt-labs-k8s
+    Latest digest: sha256:6f2aa7a8909852e08ec94d02e8854ec63eae80cddc07e6a1f41e59fa5b81802a
+    """
+    return _harbor_base(
+        package_name="titouanlne/dbt-labs-k8s",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -430,7 +430,7 @@ def agentscope_ai_pawbench(
     r"""PawBench: A comprehensive agent benchmark with 150 tasks covering coding, data analysis, tool use, reasoning, safety, and multimodal capabilities.
 
     Slug: agentscope-ai/pawbench
-    Latest digest: sha256:d2849f918a072575eeee13c79818c727f87776dac8bdc8d9c1ec084bc6bcab56
+    Latest digest: sha256:b4e0ac2e4d5614fd46735f3ece1fb98207e02ea5818b07f9d5545f97fdde2bfe
     """
     return _harbor_base(
         package_name="agentscope-ai/pawbench",
@@ -1718,37 +1718,6 @@ def grandsmile_unicode(
 
 
 @task
-def gustofied_compute_bazaar_bench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Task-based evaluations for agents working in compute markets.
-
-    Slug: gustofied/compute-bazaar-bench
-    Latest digest: sha256:cd42c9b34b8b14b6298e87fb7bd477cd7401b9ed3ff5235bfbedcceb2a7642a1
-    """
-    return _harbor_base(
-        package_name="gustofied/compute-bazaar-bench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def harbor_index(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2617,7 +2586,7 @@ def openai_swe_lancer_diamond_manager(
 
 
 @task
-def orca_bench_orca_bench(
+def orca_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -2628,7 +2597,7 @@ def orca_bench_orca_bench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""An agent benchmark for root cause analysis — public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard). For the results on all 1,079 tasks, please see https://arxiv.org/abs/2607.28545.
+    r"""ORCA-bench: root-cause analysis of oncall incidents — agents investigate telemetry from an instrumented microservices system to diagnose each incident; public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard).
 
     Slug: orca-bench/orca-bench
     Latest digest: sha256:1ef729757d4974ffe4e835d541c601f957975edf8c93ef02eec97e26d3069b93
@@ -3819,68 +3788,6 @@ def tinycomputerai_bun_server_bench(
     """
     return _harbor_base(
         package_name="tinycomputerai/bun-server-bench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def titouanlne_arc_agi_2_k8s(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""ARC-AGI-2 tasks adapted for Kubernetes sandbox execution via a shared pre-built Docker Hub image
-
-    Slug: titouanlne/arc-agi-2-k8s
-    Latest digest: sha256:bf2b0e28459d5354635332ade9fb3eee64ed6dd06eba06437e62716c3e94a86b
-    """
-    return _harbor_base(
-        package_name="titouanlne/arc-agi-2-k8s",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def titouanlne_dbt_labs_k8s(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""dbt-labs ADE-bench tasks adapted for Kubernetes sandbox execution via pre-built Docker Hub images
-
-    Slug: titouanlne/dbt-labs-k8s
-    Latest digest: sha256:6f2aa7a8909852e08ec94d02e8854ec63eae80cddc07e6a1f41e59fa5b81802a
-    """
-    return _harbor_base(
-        package_name="titouanlne/dbt-labs-k8s",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -2876,7 +2876,7 @@ def red_hat_ai_haiku_hard(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""178 Go instances that Claude Haiku failed to solve
+    r"""Hard subset of SWE-style Go bug-fixing tasks drawn from Red Hat-ecosystem repos (openshift, operator-framework, coreos) — 177 instances filtered to those Claude Haiku failed to solve.
 
     Slug: red-hat-ai/haiku-hard
     Latest digest: sha256:b24383f875f3d1ecad10aa8e8249d40fdb594fffffa3c842cf2cb0d96325a4e6

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-harbor = "2026-07-04T23:00:00Z"
+harbor = "2026-07-05T00:00:00Z"
 inspect-ai = false
 
 [[package]]
@@ -2478,7 +2478,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4157,7 +4157,7 @@ name = "zipfile-zstd"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zstandard", marker = "python_full_version < '3.14'" },
+    { name = "zstandard" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2a/2e0941bc0058d10ab37d8c578b94a19f611f6ae54f124140f2fb451f0932/zipfile-zstd-0.0.4.tar.gz", hash = "sha256:c1498e15b7922a3d1af0ea55df8b11b2af4e8f7e0e80e414e25d66899f7def89", size = 4603, upload-time = "2021-12-08T07:38:16.245Z" }
 wheels = [


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
gustofied/compute-bazaar-bench
orca-bench/orca-bench
red-hat-ai/haiku-hard
snowflake-labs/data-eng-bench
titouanlne/arc-agi-2-k8s
titouanlne/dbt-labs-k8s
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks