### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -118,3 +118,22 @@
 # (an FPGA/electronics group). Exact slug, not org-wide: revisit if nexu-io
 # ships a real, publicly documented benchmark under this name.
 - open-design/open-design
+# Internal dev artifacts of Frontis, an agent-observability product, with no
+# public provenance: the frontis GitHub org has existed since 2018 with zero
+# public repos and no verifiable affiliation; no benchmark repo, paper, or
+# announcement exists anywhere. agent-obs-core is 3 samples with internal
+# test ids (B02/B08/B08b) and working-version churn ("minor environment
+# update from v3.1.1"); generated-basic-production-traces self-describes as
+# "mechanically generated from Frontis production Historical Trials" ("MVP
+# Harbor Dataset") — a replay-pipeline artifact, not a benchmark. Revisit if
+# Frontis publishes a real benchmark repo/paper.
+- frontis/*
+# Individual's (User, bio "i have no idea what i am doing") personal
+# self-consistency experiment, not a published benchmark:
+# rating-generation-consistency's 45 tasks = 3 whimsical "neutral topics"
+# (toilet-paper orientation, hot-dog-sandwich classification, restaurant
+# etiquette) x 3 rating scales x 5 target stances. No repo, paper, or
+# announcement anywhere; the account's only Harbor-related repo is a personal
+# mirror of standard Harbor datasets that doesn't contain this one. Revisit
+# if it is ever published as a real benchmark.
+- adameubanks/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -137,6 +137,9 @@ actava-ai/chi-bench:
   title: χ-Bench
   desc: 'χ-Bench: long-horizon, policy-rich U.S. healthcare workflow agent benchmark spanning provider prior-authorization, payer utilization management, and care management (78 hub tasks).'
 
+adameubanks/rating-generation-consistency:
+  categories: []
+
 adyen/dabstep:
   categories:
   - Professional
@@ -400,6 +403,12 @@ featurebench/featurebench-modal:
   function_name: featurebench_modal
   title: FeatureBench (Modal)
 
+frontis/agent-obs-core:
+  categories: []
+
+frontis/generated-basic-production-traces:
+  categories: []
+
 futurehouse/bixbench:
   categories:
   - Science
@@ -454,6 +463,9 @@ gnucleus-ai/cad-bench:
   title: CAD-Bench
   repo: https://www.gnucleus.ai/cad-bench
 
+google-deepmind/terminal-bench-science:
+  categories: []
+
 gorilla/bfcl:
   categories:
   - Assistants
@@ -494,6 +506,9 @@ grandsmile/unicode:
   repo: https://github.com/grandsmile/UniCode
   desc: 'UniCode: competitive-programming problems systematically augmented into novel variations to probe genuine code reasoning rather than memorized solutions, scored against an oracle-verified solvable subset.'
   title: UniCode
+
+hack-verifiable-environments/hv-terminal-bench-2-1:
+  categories: []
 
 harbor-index/harbor-index:
   categories:
@@ -764,14 +779,6 @@ orinlabs/horizon-public:
   repo: https://github.com/orinlabs/horizon
   desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'
   title: Horizon
-
-pgcodellm/rebench-v2-test:
-  categories:
-  - Coding
-  arxiv: https://arxiv.org/abs/2602.23866
-  repo: https://github.com/SWE-rebench/SWE-rebench-V2
-  desc: 'SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.'
-  title: SWE-rebench V2
 
 qcircuitbench/qcircuitbench:
   categories:
@@ -1113,6 +1120,9 @@ vals/financeagent:
   repo: https://github.com/vals-ai/finance-agent
   desc: 'Vals AI Finance Agent Benchmark: expert-validated finance questions across nine task categories (retrieval, market research, projections) with EDGAR/SEC search tools for evaluating financial agents.'
   title: Vals Finance Agent
+
+vibrantlabsai/itsm-bench:
+  categories: []
 
 vmax/vmax-tasks:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -137,9 +137,6 @@ actava-ai/chi-bench:
   title: χ-Bench
   desc: 'χ-Bench: long-horizon, policy-rich U.S. healthcare workflow agent benchmark spanning provider prior-authorization, payer utilization management, and care management (78 hub tasks).'
 
-adameubanks/rating-generation-consistency:
-  categories: []
-
 adyen/dabstep:
   categories:
   - Professional
@@ -403,12 +400,6 @@ featurebench/featurebench-modal:
   function_name: featurebench_modal
   title: FeatureBench (Modal)
 
-frontis/agent-obs-core:
-  categories: []
-
-frontis/generated-basic-production-traces:
-  categories: []
-
 futurehouse/bixbench:
   categories:
   - Science
@@ -464,7 +455,11 @@ gnucleus-ai/cad-bench:
   repo: https://www.gnucleus.ai/cad-bench
 
 google-deepmind/terminal-bench-science:
-  categories: []
+  categories:
+  - Science
+  - Coding
+  repo: https://github.com/harbor-framework/terminal-bench-science
+  title: Terminal-Bench-Science
 
 gorilla/bfcl:
   categories:
@@ -508,7 +503,12 @@ grandsmile/unicode:
   title: UniCode
 
 hack-verifiable-environments/hv-terminal-bench-2-1:
-  categories: []
+  categories:
+  - Safeguards
+  - Coding
+  arxiv: https://arxiv.org/abs/2605.20744
+  repo: https://github.com/MajoRoth/hack-verifiable-environments
+  title: Hack-Verifiable Terminal Bench 2.1
 
 harbor-index/harbor-index:
   categories:
@@ -1122,7 +1122,11 @@ vals/financeagent:
   title: Vals Finance Agent
 
 vibrantlabsai/itsm-bench:
-  categories: []
+  categories:
+  - Assistants
+  - Professional
+  repo: https://github.com/vibrantlabsai/Enterprise-Worlds
+  title: ITSMBench (Enterprise-Worlds)
 
 vmax/vmax-tasks:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -110,13 +110,6 @@
   categories:
   - Medicine
   - Professional
-- title: adameubanks/rating-generation-consistency
-  path: registry/adameubanks_rating_generation_consistency.html
-  desc: 'Generate a short post for a target stance, then re-rate it on the same scale. Neutral topics only. Scales: [-1,1], [0,10], [1,5]. Reward is max(0, 1 - |norm(target) - norm(rating)|).'
-  desc_trunc: Generate a short post for a target stance, then re-rate it on the same scale. Neutral topics only…
-  task_function: adameubanks_rating_generation_consistency
-  samples: 45
-  version: latest
 - title: adyen/dabstep
   path: registry/adyen_dabstep.html
   desc: 'DABstep: real-world data analysis tasks from Adyen''s workloads requiring multi-step reasoning by LLM agents.'
@@ -428,20 +421,6 @@
   version: latest
   categories:
   - Coding
-- title: frontis/agent-obs-core
-  path: registry/frontis_agent_obs_core.html
-  desc: 'Three source-backed agent reliability tasks: fallback honesty and a paired integrity/control evaluation.'
-  desc_trunc: 'Three source-backed agent reliability tasks: fallback honesty and a paired integrity/control evalua…'
-  task_function: frontis_agent_obs_core
-  samples: 3
-  version: latest
-- title: frontis/generated-basic-production-traces
-  path: registry/frontis_generated_basic_production_traces.html
-  desc: Basic runnable replay Tasks mechanically generated from Frontis production Historical Trials.
-  desc_trunc: Basic runnable replay Tasks mechanically generated from Frontis production Historical Trials.
-  task_function: frontis_generated_basic_production_traces
-  samples: 57
-  version: latest
 - title: futurehouse/bixbench
   path: registry/futurehouse_bixbench.html
   desc: 'BixBench: real-world bioinformatics analysis capsules with open-answer questions evaluating LLM agents'' ability to author multi-step Jupyter notebooks for biological data analysis.'
@@ -511,6 +490,9 @@
   task_function: google_deepmind_terminal_bench_science
   samples: 52
   version: latest
+  categories:
+  - Science
+  - Coding
 - title: gorilla/bfcl
   path: registry/gorilla_bfcl.html
   desc: 'Berkeley Function-Calling Leaderboard: LLM tool-use across function-calling categories spanning Python, Java, JavaScript, and REST APIs.'
@@ -568,6 +550,9 @@
   task_function: hack_verifiable_environments_hv_terminal_bench_2_1
   samples: 89
   version: latest
+  categories:
+  - Safeguards
+  - Coding
 - title: harbor-index/harbor-index
   path: registry/harbor_index.html
   desc: 'Harbor Index: 80 agentic evaluation tasks spanning SWE, security, science, math, and optimization (revision 1.4).'
@@ -1292,6 +1277,9 @@
   task_function: vibrantlabsai_itsm_bench
   samples: 53
   version: latest
+  categories:
+  - Assistants
+  - Professional
 - title: vmax/vmax-tasks
   path: registry/vmax_tasks.html
   desc: Code-transformation tasks across JavaScript projects (Docusaurus, Vue, Redux).

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -110,6 +110,13 @@
   categories:
   - Medicine
   - Professional
+- title: adameubanks/rating-generation-consistency
+  path: registry/adameubanks_rating_generation_consistency.html
+  desc: 'Generate a short post for a target stance, then re-rate it on the same scale. Neutral topics only. Scales: [-1,1], [0,10], [1,5]. Reward is max(0, 1 - |norm(target) - norm(rating)|).'
+  desc_trunc: Generate a short post for a target stance, then re-rate it on the same scale. Neutral topics only…
+  task_function: adameubanks_rating_generation_consistency
+  samples: 45
+  version: latest
 - title: adyen/dabstep
   path: registry/adyen_dabstep.html
   desc: 'DABstep: real-world data analysis tasks from Adyen''s workloads requiring multi-step reasoning by LLM agents.'
@@ -421,6 +428,20 @@
   version: latest
   categories:
   - Coding
+- title: frontis/agent-obs-core
+  path: registry/frontis_agent_obs_core.html
+  desc: 'Three source-backed agent reliability tasks: fallback honesty and a paired integrity/control evaluation.'
+  desc_trunc: 'Three source-backed agent reliability tasks: fallback honesty and a paired integrity/control evalua…'
+  task_function: frontis_agent_obs_core
+  samples: 3
+  version: latest
+- title: frontis/generated-basic-production-traces
+  path: registry/frontis_generated_basic_production_traces.html
+  desc: Basic runnable replay Tasks mechanically generated from Frontis production Historical Trials.
+  desc_trunc: Basic runnable replay Tasks mechanically generated from Frontis production Historical Trials.
+  task_function: frontis_generated_basic_production_traces
+  samples: 57
+  version: latest
 - title: futurehouse/bixbench
   path: registry/futurehouse_bixbench.html
   desc: 'BixBench: real-world bioinformatics analysis capsules with open-answer questions evaluating LLM agents'' ability to author multi-step Jupyter notebooks for biological data analysis.'
@@ -483,6 +504,13 @@
   categories:
   - Coding
   - Professional
+- title: google-deepmind/terminal-bench-science
+  path: registry/google_deepmind_terminal_bench_science.html
+  desc: 'Terminal-Bench Science: 52 expert-level scientific research tasks, flattened from harbor-framework/terminal-bench-science commit 8d2935da4468687477d714e1dd97d5c07688c9b4.'
+  desc_trunc: 'Terminal-Bench Science: 52 expert-level scientific research tasks, flattened from harbor-framework/…'
+  task_function: google_deepmind_terminal_bench_science
+  samples: 52
+  version: latest
 - title: gorilla/bfcl
   path: registry/gorilla_bfcl.html
   desc: 'Berkeley Function-Calling Leaderboard: LLM tool-use across function-calling categories spanning Python, Java, JavaScript, and REST APIs.'
@@ -533,6 +561,13 @@
   version: latest
   categories:
   - Coding
+- title: hack-verifiable-environments/hv-terminal-bench-2-1
+  path: registry/hack_verifiable_environments_hv_terminal_bench_2_1.html
+  desc: Hack-verifiable version of terminal-bench-2-1. Each task includes hidden solution and test files; inotifywait detects whether agents access them instead of solving legitimately.
+  desc_trunc: Hack-verifiable version of terminal-bench-2-1. Each task includes hidden solution and test files; i…
+  task_function: hack_verifiable_environments_hv_terminal_bench_2_1
+  samples: 89
+  version: latest
 - title: harbor-index/harbor-index
   path: registry/harbor_index.html
   desc: 'Harbor Index: 80 agentic evaluation tasks spanning SWE, security, science, math, and optimization (revision 1.4).'
@@ -858,15 +893,6 @@
   version: latest
   categories:
   - Assistants
-- title: pgcodellm/rebench-v2-test
-  path: registry/pgcodellm_rebench_v2_test.html
-  desc: 'SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.'
-  desc_trunc: 'SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-bui…'
-  task_function: pgcodellm_rebench_v2_test
-  samples: 20
-  version: latest
-  categories:
-  - Coding
 - title: qcircuitbench/qcircuitbench
   path: registry/qcircuitbench.html
   desc: 'QCircuitBench: large-scale benchmark for LLM-driven quantum-algorithm design, spanning oracle construction, algorithm design, and random circuits with automatic verification.'
@@ -1259,6 +1285,13 @@
   - Professional
   - Finance
   - Assistants
+- title: vibrantlabsai/itsm-bench
+  path: registry/vibrantlabsai_itsm_bench.html
+  desc: 'ITSMBench: enterprise ITSM agent tasks graded on database state.'
+  desc_trunc: 'ITSMBench: enterprise ITSM agent tasks graded on database state.'
+  task_function: vibrantlabsai_itsm_bench
+  samples: 53
+  version: latest
 - title: vmax/vmax-tasks
   path: registry/vmax_tasks.html
   desc: Code-transformation tasks across JavaScript projects (Docusaurus, Vue, Redux).

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -354,6 +354,37 @@ def actava_ai_chi_bench(
 
 
 @task
+def adameubanks_rating_generation_consistency(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Generate a short post for a target stance, then re-rate it on the same scale. Neutral topics only. Scales: [-1,1], [0,10], [1,5]. Reward is max(0, 1 - |norm(target) - norm(rating)|).
+
+    Slug: adameubanks/rating-generation-consistency
+    Latest digest: sha256:a158b86d216f467af89bb2fd149c7606c169c65896f5bb92c7e1810dfad84d7d
+    """
+    return _harbor_base(
+        package_name="adameubanks/rating-generation-consistency",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def adyen_dabstep(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1377,6 +1408,68 @@ def featurebench_modal(
 
 
 @task
+def frontis_agent_obs_core(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Three source-backed agent reliability tasks: fallback honesty and a paired integrity/control evaluation.
+
+    Slug: frontis/agent-obs-core
+    Latest digest: sha256:289ab23cc35406714bff7a804ed5d5161eb744a3b7719da0a57af7c3e5f41179
+    """
+    return _harbor_base(
+        package_name="frontis/agent-obs-core",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def frontis_generated_basic_production_traces(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Basic runnable replay Tasks mechanically generated from Frontis production Historical Trials.
+
+    Slug: frontis/generated-basic-production-traces
+    Latest digest: sha256:4382bf298aa0893ef0683cb38a27e59d1ad8ca66bb1f0e02160fa618b0a6a730
+    """
+    return _harbor_base(
+        package_name="frontis/generated-basic-production-traces",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def futurehouse_bixbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1563,6 +1656,37 @@ def gnucleus_ai_cad_bench(
 
 
 @task
+def google_deepmind_terminal_bench_science(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Terminal-Bench Science: 52 expert-level scientific research tasks, flattened from harbor-framework/terminal-bench-science commit 8d2935da4468687477d714e1dd97d5c07688c9b4.
+
+    Slug: google-deepmind/terminal-bench-science
+    Latest digest: sha256:4fa7a9af5ecaa4c0c942d4284d32a37d747629c0b288fba796a2c4436b1e965f
+    """
+    return _harbor_base(
+        package_name="google-deepmind/terminal-bench-science",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def gorilla_bfcl(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1705,6 +1829,37 @@ def grandsmile_unicode(
     """
     return _harbor_base(
         package_name="grandsmile/unicode",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def hack_verifiable_environments_hv_terminal_bench_2_1(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Hack-verifiable version of terminal-bench-2-1. Each task includes hidden solution and test files; inotifywait detects whether agents access them instead of solving legitimately.
+
+    Slug: hack-verifiable-environments/hv-terminal-bench-2-1
+    Latest digest: sha256:f77c76cd022b0aec434bc755ac1cfd8da650237c72047f189747fa10e33f6907
+    """
+    return _harbor_base(
+        package_name="hack-verifiable-environments/hv-terminal-bench-2-1",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -2772,37 +2927,6 @@ def orinlabs_horizon_public(
 
 
 @task
-def pgcodellm_rebench_v2_test(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.
-
-    Slug: pgcodellm/rebench-v2-test
-    Latest digest: sha256:69488f0f1f51c1fed4ca5271b92b63b96deb4b0f2252d8654285a8fea173deb0
-    """
-    return _harbor_base(
-        package_name="pgcodellm/rebench-v2-test",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def qcircuitbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3133,7 +3257,7 @@ def rounakbende10_rh_swe_bench(
     r"""Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos
 
     Slug: rounakbende10/rh-swe-bench
-    Latest digest: sha256:2912e953dd598963a5e7bb54f5fa6524baac1a073f1debd2bf1d6e1fad990d66
+    Latest digest: sha256:c0a3c223a96b0536e69a4b382c731f425285538f9bbc10972a203613aa4ffad2
     """
     return _harbor_base(
         package_name="rounakbende10/rh-swe-bench",
@@ -4067,6 +4191,37 @@ def vals_financeagent(
     """
     return _harbor_base(
         package_name="vals/financeagent",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def vibrantlabsai_itsm_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""ITSMBench: enterprise ITSM agent tasks graded on database state
+
+    Slug: vibrantlabsai/itsm-bench
+    Latest digest: sha256:401272f2e121cdfed9212683f838d0fd77a750f575e97598664578be09905174
+    """
+    return _harbor_base(
+        package_name="vibrantlabsai/itsm-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -354,37 +354,6 @@ def actava_ai_chi_bench(
 
 
 @task
-def adameubanks_rating_generation_consistency(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Generate a short post for a target stance, then re-rate it on the same scale. Neutral topics only. Scales: [-1,1], [0,10], [1,5]. Reward is max(0, 1 - |norm(target) - norm(rating)|).
-
-    Slug: adameubanks/rating-generation-consistency
-    Latest digest: sha256:a158b86d216f467af89bb2fd149c7606c169c65896f5bb92c7e1810dfad84d7d
-    """
-    return _harbor_base(
-        package_name="adameubanks/rating-generation-consistency",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def adyen_dabstep(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1395,68 +1364,6 @@ def featurebench_modal(
     """
     return _harbor_base(
         package_name="featurebench/featurebench-modal",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def frontis_agent_obs_core(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Three source-backed agent reliability tasks: fallback honesty and a paired integrity/control evaluation.
-
-    Slug: frontis/agent-obs-core
-    Latest digest: sha256:289ab23cc35406714bff7a804ed5d5161eb744a3b7719da0a57af7c3e5f41179
-    """
-    return _harbor_base(
-        package_name="frontis/agent-obs-core",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def frontis_generated_basic_production_traces(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Basic runnable replay Tasks mechanically generated from Frontis production Historical Trials.
-
-    Slug: frontis/generated-basic-production-traces
-    Latest digest: sha256:4382bf298aa0893ef0683cb38a27e59d1ad8ca66bb1f0e02160fa618b0a6a730
-    """
-    return _harbor_base(
-        package_name="frontis/generated-basic-production-traces",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
adameubanks/rating-generation-consistency
frontis/agent-obs-core
frontis/generated-basic-production-traces
google-deepmind/terminal-bench-science
hack-verifiable-environments/hv-terminal-bench-2-1
vibrantlabsai/itsm-bench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks