### PR TITLE
fix: run verifier.collect commands before scoring

### DIFF
--- a/src/inspect_harbor/_harbor/scorer.py
+++ b/src/inspect_harbor/_harbor/scorer.py
@@ -90,6 +90,18 @@ def harbor_scorer(
         await sandbox().exec(["mkdir", "-p", "/logs/agent"])
         await sandbox().exec(["mkdir", "-p", "/logs/verifier"])
 
+        # Run verifier.collect commands to gather artifacts (e.g. model.patch)
+        harbor_config = state.metadata.get("harbor_config", {})
+        collect_steps = harbor_config.get("verifier", {}).get("collect", [])
+        for step in collect_steps:
+            collect_cmd = step.get("command", "")
+            if collect_cmd:
+                await sandbox().exec(
+                    ["bash", "-c", collect_cmd],
+                    timeout=int(step.get("timeout_sec", 300)),
+                    user=step.get("user") or state.metadata.get("agent_user"),
+                )
+
         verifier_env_raw = state.metadata.get("verifier_env", {})
         resolved_user_env = (
             resolve_env_vars(verifier_env_raw) if verifier_env_raw else {}

--- a/src/inspect_harbor/_harbor/scorer.py
+++ b/src/inspect_harbor/_harbor/scorer.py
@@ -102,6 +102,16 @@ def harbor_scorer(
                     user=step.get("user") or state.metadata.get("agent_user"),
                 )
 
+        # When verifier.environment_mode is "separate", Harbor runs the
+        # verifier in a fresh container at the base commit.  We share a
+        # single container, so reset the repo after collecting artifacts.
+        base_commit = harbor_config.get("metadata", {}).get("base_commit_hash")
+        if collect_steps and base_commit:
+            await sandbox().exec(
+                ["bash", "-c", f"cd /app && git checkout -f {base_commit} && git clean -fd"],
+                timeout=60,
+            )
+
         verifier_env_raw = state.metadata.get("verifier_env", {})
         resolved_user_env = (
             resolve_env_vars(verifier_env_raw) if verifier_env_raw else {}

--- a/src/inspect_harbor/_harbor/scorer.py
+++ b/src/inspect_harbor/_harbor/scorer.py
@@ -1,20 +1,27 @@
 """Scorer for Harbor tasks in Inspect AI."""
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
+from harbor.constants import MAIN_SERVICE_NAME
+from harbor.models.task.config import TaskConfig, VerifierEnvironmentMode
+from harbor.models.task.verifier_mode import resolve_task_verifier_mode
 from harbor.models.trial.paths import EnvironmentPaths
 from inspect_ai.scorer import Score, Scorer, Target, accuracy, scorer, stderr
 from inspect_ai.solver import TaskState
 from inspect_ai.util import sandbox
 
+from inspect_harbor._harbor.converters import _user_to_str
 from inspect_harbor._harbor.sandbox_utils import (
     cleanup_sandbox_directories,
     cleanup_sandbox_env_vars,
     copy_directory_to_sandbox,
     resolve_env_vars,
 )
+
+logger = logging.getLogger(__name__)
 
 # ``TEST_DIR`` is a Terminal-Bench convention some verifier scripts rely on.
 _DEFAULT_VERIFIER_ENV: dict[str, str] = {
@@ -86,31 +93,17 @@ def harbor_scorer(
                 f"Test path {test_path} is not relative to tests directory {tests_dir}"
             ) from e
 
-        # Create Harbor's standard log directories
+        # Create Harbor's standard log directories. Harbor bind-mounts and
+        # pre-creates /logs/artifacts, so create it here too since collect
+        # hooks may assume it exists.
         await sandbox().exec(["mkdir", "-p", "/logs/agent"])
         await sandbox().exec(["mkdir", "-p", "/logs/verifier"])
+        await sandbox().exec(["mkdir", "-p", "/logs/artifacts"])
 
-        # Run verifier.collect commands to gather artifacts (e.g. model.patch)
-        harbor_config = state.metadata.get("harbor_config", {})
-        collect_steps = harbor_config.get("verifier", {}).get("collect", [])
-        for step in collect_steps:
-            collect_cmd = step.get("command", "")
-            if collect_cmd:
-                await sandbox().exec(
-                    ["bash", "-c", collect_cmd],
-                    timeout=int(step.get("timeout_sec", 300)),
-                    user=step.get("user") or state.metadata.get("agent_user"),
-                )
-
-        # When verifier.environment_mode is "separate", Harbor runs the
-        # verifier in a fresh container at the base commit.  We share a
-        # single container, so reset the repo after collecting artifacts.
-        base_commit = harbor_config.get("metadata", {}).get("base_commit_hash")
-        if collect_steps and base_commit:
-            await sandbox().exec(
-                ["bash", "-c", f"cd /app && git checkout -f {base_commit} && git clean -fd"],
-                timeout=60,
-            )
+        # Run [[verifier.collect]] hooks to gather artifacts (e.g. model.patch)
+        harbor_config = state.metadata.get("harbor_config")
+        if harbor_config:
+            await _run_verifier_collect(harbor_config)
 
         verifier_env_raw = state.metadata.get("verifier_env", {})
         resolved_user_env = (
@@ -142,6 +135,78 @@ def harbor_scorer(
         return score_result
 
     return score
+
+
+async def _run_verifier_collect(harbor_config: dict[str, Any]) -> None:
+    """Run ``[[verifier.collect]]`` hooks and, in separate mode, reset the repo.
+
+    Harbor runs collect hooks in their target compose service after the agent
+    phase ends and before verification, then, when the verifier runs in
+    ``separate`` mode, builds the verifier in a fresh container at the base
+    commit. We share a single container, so we run the hooks here and
+    approximate the fresh verifier container by resetting the repo to the base
+    commit. The reset is only an approximation: Harbor's separate verifier may
+    use a different image than the agent container.
+    """
+    task_cfg = TaskConfig.model_validate(harbor_config)
+    collect_steps = task_cfg.verifier.collect
+    if not collect_steps:
+        return
+
+    workdir = task_cfg.environment.workdir or "/app"
+
+    for step in collect_steps:
+        # ``sandbox()`` only addresses the default (main) compose service, so
+        # hooks targeting a sidecar can't be honored here.
+        if step.service != MAIN_SERVICE_NAME:
+            logger.warning(
+                "Skipping verifier.collect hook targeting non-main service %r: %r",
+                step.service,
+                step.command,
+            )
+            continue
+
+        # Harbor runs collect hooks as ``hook.user`` (falling back to the
+        # container's default user), not the agent user.
+        result = await sandbox().exec(
+            ["bash", "-c", step.command],
+            timeout=int(step.timeout_sec),
+            user=_user_to_str(step.user),
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "verifier.collect hook exited %d: %r\nstdout:\n%s\nstderr:\n%s",
+                result.returncode,
+                step.command,
+                result.stdout,
+                result.stderr,
+            )
+
+    # Only reset in separate mode; in shared mode Harbor verifies against the
+    # agent's environment, so wiping its work would grade the pristine base.
+    if resolve_task_verifier_mode(task_cfg) != VerifierEnvironmentMode.SEPARATE:
+        return
+
+    base_commit = task_cfg.metadata.get("base_commit_hash")
+    if not base_commit:
+        return
+
+    # The agent may have committed as a non-root user, so mark the repo safe to
+    # avoid git's "dubious ownership" error when resetting as the default user.
+    reset_cmd = (
+        f"cd {workdir} && "
+        "git config --global --add safe.directory '*' && "
+        f"git checkout -f {base_commit} && git clean -fd"
+    )
+    result = await sandbox().exec(["bash", "-c", reset_cmd], timeout=60)
+    if result.returncode != 0:
+        logger.warning(
+            "repo reset to base commit %r exited %d\nstdout:\n%s\nstderr:\n%s",
+            base_commit,
+            result.returncode,
+            result.stdout,
+            result.stderr,
+        )
 
 
 async def _parse_reward_file(exit_code: int) -> tuple[float, dict[str, Any] | None]:

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1017,12 +1017,13 @@ async def test_harbor_scorer_cleans_up_env_vars_after_scoring(
 
 @pytest.mark.asyncio
 async def test_harbor_scorer_runs_verifier_collect(tmp_path: Path) -> None:
-    """Verifier.collect commands run after log dirs are created but before tests."""
+    """Verifier.collect commands run after log dirs, then repo resets to base commit."""
     tests_dir = tmp_path / "tests"
     tests_dir.mkdir()
     test_script = tests_dir / "test.sh"
     test_script.write_text("#!/bin/bash\necho 'test'")
 
+    base_commit = "abc123"
     mock_state = Mock(spec=TaskState)
     mock_state.metadata = {
         "tests_dir": str(tests_dir),
@@ -1030,6 +1031,7 @@ async def test_harbor_scorer_runs_verifier_collect(tmp_path: Path) -> None:
         "verifier_timeout_sec": 60,
         "agent_user": "agent",
         "harbor_config": {
+            "metadata": {"base_commit_hash": base_commit},
             "verifier": {
                 "collect": [
                     {
@@ -1074,7 +1076,12 @@ async def test_harbor_scorer_runs_verifier_collect(tmp_path: Path) -> None:
         "-c",
         "git diff HEAD > /logs/artifacts/model.patch",
     ]
-    assert exec_calls[3] == ["bash", "-l", "/tests/test.sh"]
+    assert exec_calls[3] == [
+        "bash",
+        "-c",
+        f"cd /app && git checkout -f {base_commit} && git clean -fd",
+    ]
+    assert exec_calls[4] == ["bash", "-l", "/tests/test.sh"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1016,6 +1016,115 @@ async def test_harbor_scorer_cleans_up_env_vars_after_scoring(
 
 
 @pytest.mark.asyncio
+async def test_harbor_scorer_runs_verifier_collect(tmp_path: Path) -> None:
+    """Verifier.collect commands run after log dirs are created but before tests."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_script = tests_dir / "test.sh"
+    test_script.write_text("#!/bin/bash\necho 'test'")
+
+    mock_state = Mock(spec=TaskState)
+    mock_state.metadata = {
+        "tests_dir": str(tests_dir),
+        "test_path": str(test_script),
+        "verifier_timeout_sec": 60,
+        "agent_user": "agent",
+        "harbor_config": {
+            "verifier": {
+                "collect": [
+                    {
+                        "command": "git diff HEAD > /logs/artifacts/model.patch",
+                        "timeout_sec": 120,
+                        "user": None,
+                    }
+                ],
+            },
+        },
+    }
+    mock_target = Mock(spec=Target)
+
+    exec_calls: list[list[str]] = []
+
+    async def track_exec(cmd: list[str], **_kwargs: object) -> Mock:
+        exec_calls.append(cmd)
+        result = Mock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    mock_sandbox = Mock()
+    mock_sandbox.write_file = AsyncMock()
+    mock_sandbox.exec = AsyncMock(side_effect=track_exec)
+    mock_sandbox.read_file = AsyncMock(return_value="1.0")
+
+    with (
+        patch("inspect_harbor._harbor.scorer.sandbox", return_value=mock_sandbox),
+        patch(
+            "inspect_harbor._harbor.sandbox_utils.sandbox",
+            return_value=mock_sandbox,
+        ),
+    ):
+        await harbor_scorer()(mock_state, mock_target)
+
+    assert exec_calls[0] == ["mkdir", "-p", "/logs/agent"]
+    assert exec_calls[1] == ["mkdir", "-p", "/logs/verifier"]
+    assert exec_calls[2] == [
+        "bash",
+        "-c",
+        "git diff HEAD > /logs/artifacts/model.patch",
+    ]
+    assert exec_calls[3] == ["bash", "-l", "/tests/test.sh"]
+
+
+@pytest.mark.asyncio
+async def test_harbor_scorer_skips_empty_collect(tmp_path: Path) -> None:
+    """Empty or missing collect steps don't produce extra exec calls."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_script = tests_dir / "test.sh"
+    test_script.write_text("#!/bin/bash\necho 'test'")
+
+    mock_state = Mock(spec=TaskState)
+    mock_state.metadata = {
+        "tests_dir": str(tests_dir),
+        "test_path": str(test_script),
+        "verifier_timeout_sec": 60,
+        "harbor_config": {"verifier": {"collect": []}},
+    }
+    mock_target = Mock(spec=Target)
+
+    exec_calls: list[list[str]] = []
+
+    async def track_exec(cmd: list[str], **_kwargs: object) -> Mock:
+        exec_calls.append(cmd)
+        result = Mock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    mock_sandbox = Mock()
+    mock_sandbox.write_file = AsyncMock()
+    mock_sandbox.exec = AsyncMock(side_effect=track_exec)
+    mock_sandbox.read_file = AsyncMock(return_value="1.0")
+
+    with (
+        patch("inspect_harbor._harbor.scorer.sandbox", return_value=mock_sandbox),
+        patch(
+            "inspect_harbor._harbor.sandbox_utils.sandbox",
+            return_value=mock_sandbox,
+        ),
+    ):
+        await harbor_scorer()(mock_state, mock_target)
+
+    # No collect exec — straight from mkdir to test script
+    assert exec_calls[0] == ["mkdir", "-p", "/logs/agent"]
+    assert exec_calls[1] == ["mkdir", "-p", "/logs/verifier"]
+    assert exec_calls[2] == ["bash", "-l", "/tests/test.sh"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "verifier_user,expected_user_kwarg",
     [

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -517,15 +517,16 @@ async def test_harbor_scorer_calls_cleanup_after_scoring(tmp_path: Path):
             assert result.metadata is None  # reward.txt returns None for reward_dict
 
             # Verify cleanup was called AFTER scoring. Sequence:
-            # mkdir /logs/agent, mkdir /logs/verifier, bash test.sh,
-            # rm /tests, rm /logs/verifier, then unset for each default env
-            # var (currently just TEST_DIR).
+            # mkdir /logs/agent, mkdir /logs/verifier, mkdir /logs/artifacts,
+            # bash test.sh, rm /tests, rm /logs/verifier, then unset for each
+            # default env var (currently just TEST_DIR).
             assert exec_calls[0] == ["mkdir", "-p", "/logs/agent"]
             assert exec_calls[1] == ["mkdir", "-p", "/logs/verifier"]
-            assert exec_calls[2] == ["bash", "-l", "/tests/test.sh"]
-            assert exec_calls[3] == ["rm", "-rf", "/tests"]
-            assert exec_calls[4] == ["rm", "-rf", "/logs/verifier"]
-            assert ["unset", "TEST_DIR"] in exec_calls[5:]
+            assert exec_calls[2] == ["mkdir", "-p", "/logs/artifacts"]
+            assert exec_calls[3] == ["bash", "-l", "/tests/test.sh"]
+            assert exec_calls[4] == ["rm", "-rf", "/tests"]
+            assert exec_calls[5] == ["rm", "-rf", "/logs/verifier"]
+            assert ["unset", "TEST_DIR"] in exec_calls[6:]
 
 
 @pytest.mark.asyncio
@@ -1001,23 +1002,24 @@ async def test_harbor_scorer_cleans_up_env_vars_after_scoring(
             assert result.value == 1.0
 
             # Verify cleanup was called AFTER scoring. Expected sequence:
-            # mkdir /logs/agent, mkdir /logs/verifier, bash test.sh,
-            # rm /tests, rm /logs/verifier, then unset for each env var
-            # (TEST_DIR default + the two user-supplied).
+            # mkdir /logs/agent, mkdir /logs/verifier, mkdir /logs/artifacts,
+            # bash test.sh, rm /tests, rm /logs/verifier, then unset for each
+            # env var (TEST_DIR default + the two user-supplied).
             assert exec_calls[0] == ["mkdir", "-p", "/logs/agent"]
             assert exec_calls[1] == ["mkdir", "-p", "/logs/verifier"]
-            assert exec_calls[2] == ["bash", "-l", "/tests/test.sh"]
-            assert exec_calls[3] == ["rm", "-rf", "/tests"]
-            assert exec_calls[4] == ["rm", "-rf", "/logs/verifier"]
+            assert exec_calls[2] == ["mkdir", "-p", "/logs/artifacts"]
+            assert exec_calls[3] == ["bash", "-l", "/tests/test.sh"]
+            assert exec_calls[4] == ["rm", "-rf", "/tests"]
+            assert exec_calls[5] == ["rm", "-rf", "/logs/verifier"]
             # Check cleanup was called for all env vars (user + defaults).
-            env_cleanup_calls = exec_calls[5:]
+            env_cleanup_calls = exec_calls[6:]
             assert ["unset", "OPENAI_API_KEY"] in env_cleanup_calls
             assert ["unset", "MODEL_NAME"] in env_cleanup_calls
 
 
 @pytest.mark.asyncio
 async def test_harbor_scorer_runs_verifier_collect(tmp_path: Path) -> None:
-    """Verifier.collect commands run after log dirs, then repo resets to base commit."""
+    """Separate-mode collect hooks run after log dirs, then repo resets to base."""
     tests_dir = tmp_path / "tests"
     tests_dir.mkdir()
     test_script = tests_dir / "test.sh"
@@ -1033,12 +1035,183 @@ async def test_harbor_scorer_runs_verifier_collect(tmp_path: Path) -> None:
         "harbor_config": {
             "metadata": {"base_commit_hash": base_commit},
             "verifier": {
+                "environment_mode": "separate",
                 "collect": [
                     {
                         "command": "git diff HEAD > /logs/artifacts/model.patch",
                         "timeout_sec": 120,
                         "user": None,
                     }
+                ],
+            },
+        },
+    }
+    mock_target = Mock(spec=Target)
+
+    exec_calls: list[dict[str, Any]] = []
+
+    async def track_exec(cmd: list[str], **kwargs: Any) -> Mock:
+        exec_calls.append({"cmd": cmd, "kwargs": kwargs})
+        result = Mock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    mock_sandbox = Mock()
+    mock_sandbox.write_file = AsyncMock()
+    mock_sandbox.exec = AsyncMock(side_effect=track_exec)
+    mock_sandbox.read_file = AsyncMock(return_value="1.0")
+
+    with (
+        patch("inspect_harbor._harbor.scorer.sandbox", return_value=mock_sandbox),
+        patch(
+            "inspect_harbor._harbor.sandbox_utils.sandbox",
+            return_value=mock_sandbox,
+        ),
+    ):
+        await harbor_scorer()(mock_state, mock_target)
+
+    cmds = [call["cmd"] for call in exec_calls]
+    assert cmds[0] == ["mkdir", "-p", "/logs/agent"]
+    assert cmds[1] == ["mkdir", "-p", "/logs/verifier"]
+    assert cmds[2] == ["mkdir", "-p", "/logs/artifacts"]
+    assert exec_calls[3]["cmd"] == [
+        "bash",
+        "-c",
+        "git diff HEAD > /logs/artifacts/model.patch",
+    ]
+    # hook.user is None -> no agent_user fallback, timeout from the hook config
+    assert exec_calls[3]["kwargs"]["user"] is None
+    assert exec_calls[3]["kwargs"]["timeout"] == 120
+    assert exec_calls[4]["cmd"] == [
+        "bash",
+        "-c",
+        f"cd /app && git config --global --add safe.directory '*' && "
+        f"git checkout -f {base_commit} && git clean -fd",
+    ]
+    assert cmds[5] == ["bash", "-l", "/tests/test.sh"]
+
+
+@pytest.mark.asyncio
+async def test_harbor_scorer_collect_coerces_int_user(tmp_path: Path) -> None:
+    """An integer ``user`` UID from task.toml is coerced to a str for exec."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_script = tests_dir / "test.sh"
+    test_script.write_text("#!/bin/bash\necho 'test'")
+
+    mock_state = Mock(spec=TaskState)
+    mock_state.metadata = {
+        "tests_dir": str(tests_dir),
+        "test_path": str(test_script),
+        "verifier_timeout_sec": 60,
+        "harbor_config": {
+            "verifier": {
+                "collect": [{"command": "echo hi", "user": 1000}],
+            },
+        },
+    }
+    mock_target = Mock(spec=Target)
+
+    exec_calls: list[dict[str, Any]] = []
+
+    async def track_exec(cmd: list[str], **kwargs: Any) -> Mock:
+        exec_calls.append({"cmd": cmd, "kwargs": kwargs})
+        result = Mock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    mock_sandbox = Mock()
+    mock_sandbox.write_file = AsyncMock()
+    mock_sandbox.exec = AsyncMock(side_effect=track_exec)
+    mock_sandbox.read_file = AsyncMock(return_value="1.0")
+
+    with (
+        patch("inspect_harbor._harbor.scorer.sandbox", return_value=mock_sandbox),
+        patch(
+            "inspect_harbor._harbor.sandbox_utils.sandbox",
+            return_value=mock_sandbox,
+        ),
+    ):
+        await harbor_scorer()(mock_state, mock_target)
+
+    hook_call = next(call for call in exec_calls if call["cmd"][:2] == ["bash", "-c"])
+    assert hook_call["kwargs"]["user"] == "1000"
+
+
+@pytest.mark.asyncio
+async def test_harbor_scorer_shared_mode_no_reset(tmp_path: Path) -> None:
+    """A shared-mode task with collect + base_commit does not reset the repo."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_script = tests_dir / "test.sh"
+    test_script.write_text("#!/bin/bash\necho 'test'")
+
+    mock_state = Mock(spec=TaskState)
+    mock_state.metadata = {
+        "tests_dir": str(tests_dir),
+        "test_path": str(test_script),
+        "verifier_timeout_sec": 60,
+        "harbor_config": {
+            "metadata": {"base_commit_hash": "abc123"},
+            # No environment_mode / environment -> resolves to "shared".
+            "verifier": {
+                "collect": [{"command": "echo collect"}],
+            },
+        },
+    }
+    mock_target = Mock(spec=Target)
+
+    exec_calls: list[list[str]] = []
+
+    async def track_exec(cmd: list[str], **_kwargs: object) -> Mock:
+        exec_calls.append(cmd)
+        result = Mock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    mock_sandbox = Mock()
+    mock_sandbox.write_file = AsyncMock()
+    mock_sandbox.exec = AsyncMock(side_effect=track_exec)
+    mock_sandbox.read_file = AsyncMock(return_value="1.0")
+
+    with (
+        patch("inspect_harbor._harbor.scorer.sandbox", return_value=mock_sandbox),
+        patch(
+            "inspect_harbor._harbor.sandbox_utils.sandbox",
+            return_value=mock_sandbox,
+        ),
+    ):
+        await harbor_scorer()(mock_state, mock_target)
+
+    # Collect runs, but no git reset is issued.
+    assert ["bash", "-c", "echo collect"] in exec_calls
+    assert not any("git checkout" in " ".join(cmd) for cmd in exec_calls)
+
+
+@pytest.mark.asyncio
+async def test_harbor_scorer_skips_non_main_service_collect(tmp_path: Path) -> None:
+    """Collect hooks targeting a sidecar service are skipped (only main is reachable)."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_script = tests_dir / "test.sh"
+    test_script.write_text("#!/bin/bash\necho 'test'")
+
+    mock_state = Mock(spec=TaskState)
+    mock_state.metadata = {
+        "tests_dir": str(tests_dir),
+        "test_path": str(test_script),
+        "verifier_timeout_sec": 60,
+        "harbor_config": {
+            "verifier": {
+                "collect": [
+                    {"command": "pg_dump db", "service": "db"},
+                    {"command": "echo main", "service": "main"},
                 ],
             },
         },
@@ -1069,19 +1242,8 @@ async def test_harbor_scorer_runs_verifier_collect(tmp_path: Path) -> None:
     ):
         await harbor_scorer()(mock_state, mock_target)
 
-    assert exec_calls[0] == ["mkdir", "-p", "/logs/agent"]
-    assert exec_calls[1] == ["mkdir", "-p", "/logs/verifier"]
-    assert exec_calls[2] == [
-        "bash",
-        "-c",
-        "git diff HEAD > /logs/artifacts/model.patch",
-    ]
-    assert exec_calls[3] == [
-        "bash",
-        "-c",
-        f"cd /app && git checkout -f {base_commit} && git clean -fd",
-    ]
-    assert exec_calls[4] == ["bash", "-l", "/tests/test.sh"]
+    assert ["bash", "-c", "echo main"] in exec_calls
+    assert ["bash", "-c", "pg_dump db"] not in exec_calls
 
 
 @pytest.mark.asyncio
@@ -1128,7 +1290,8 @@ async def test_harbor_scorer_skips_empty_collect(tmp_path: Path) -> None:
     # No collect exec — straight from mkdir to test script
     assert exec_calls[0] == ["mkdir", "-p", "/logs/agent"]
     assert exec_calls[1] == ["mkdir", "-p", "/logs/verifier"]
-    assert exec_calls[2] == ["bash", "-l", "/tests/test.sh"]
+    assert exec_calls[2] == ["mkdir", "-p", "/logs/artifacts"]
+    assert exec_calls[3] == ["bash", "-l", "/tests/test.sh"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**The below change has been verified to be effective by a human.** These changes were used to effectively evaluate these models: https://huggingface.co/RedHatAI/Qwen3.8-2.4T-A95B-NVFP4-REAP-25.

* Fixes #163

## Summary

- Run `[[verifier.collect]]` commands from `task.toml` after creating log directories but before executing the test script in `harbor_scorer()`
- In `separate` verifier mode, reset the repo to `base_commit_hash` after collecting artifacts, approximating Harbor's fresh verifier container
- Without this, tasks that rely on collect hooks to generate artifacts (e.g. DeepSWE 1.1 generating `model.patch` via `git diff`) always grade the pristine base state, producing incorrect scores

## Current behavior

`harbor_scorer()` goes directly from creating log directories to running the test script. Any `verifier.collect` commands declared in `task.toml` are ignored. For tasks like DeepSWE 1.1 where all 113 tasks declare a collect step to generate `model.patch` from the agent's git commits, the verifier finds no patch file and grades the unmodified codebase — yielding accuracy of approximately -0.35 (most tests fail on the pristine base).

## New behavior

`harbor_scorer()` reconstructs the `TaskConfig` from sample metadata and, between creating the log directories and running the verifier test script:

- Executes each `verifier.collect` command (via `bash -c`) in the main compose service, as the hook's configured user (falling back to the container default), matching Harbor. Hooks targeting a sidecar service are skipped with a warning, and non-zero exits are logged.
- When the verifier resolves to `separate` mode (via `resolve_task_verifier_mode`) and `base_commit_hash` metadata is present, resets `/app` (or `environment.workdir`) to the base commit with `git checkout -f` / `git clean -fd`, approximating Harbor's fresh verifier container. In `shared` mode the repo is left untouched so the agent's work is graded.

## Breaking changes

None for existing tasks. Tasks without `verifier.collect` are unaffected. Tasks that declare collect hooks now have them executed in the shared container (Harbor's documented behavior); a hook that fails only degrades to today's behavior (no artifact). The repo reset only runs in `separate` mode.

## Test plan

- [x] `test_harbor_scorer_runs_verifier_collect` — separate-mode collect runs after mkdir, then repo resets to base, before test.sh (asserts `timeout`/`user` kwargs)
- [x] `test_harbor_scorer_collect_coerces_int_user` — an integer `user` UID is coerced to `str`
- [x] `test_harbor_scorer_shared_mode_no_reset` — shared-mode task with collect + `base_commit_hash` does not reset the repo
- [x] `test_harbor_scorer_skips_non_main_service_collect` — sidecar-targeted hooks are skipped
- [x] `test_harbor_scorer_skips_empty_collect` — empty/missing collect adds no extra exec calls
- [x] Full suite (197 tests) passes; `ruff check`/`ruff format --check`/`pyright` clean

## Other information

### Agent review
- Reviewer: Claude Opus 4.6 (same context as author), 1 pass
- Findings: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
