### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -4125,7 +4125,7 @@ def vibrantlabsai_itsm_bench(
     r"""ITSMBench: enterprise ITSM agent tasks graded on database state
 
     Slug: vibrantlabsai/itsm-bench
-    Latest digest: sha256:401272f2e121cdfed9212683f838d0fd77a750f575e97598664578be09905174
+    Latest digest: sha256:b26edd5cb47cfe17f2db4b4cbe4bbba98307dc1aba1358e73f4171b342717620
     """
     return _harbor_base(
         package_name="vibrantlabsai/itsm-bench",


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
(none — all datasets already had overrides)
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks