### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -149,3 +149,26 @@
 # Canonical releases live under terminal-bench/. Revisit if a real personal
 # benchmark appears under this account.
 - ryanmarten/*
+# TEMPORARILY excluded (would otherwise be kept): four legitimate-looking
+# Blobfish AI benchmarks that fail to load because inspect_ai's ComposeConfig
+# rejects docker-compose long-form volume mounts
+# (services.main.volumes.0: Input should be a valid string). Re-include and
+# categorize once inspect_ai supports them (fix proposed upstream):
+# counselbench-100 ~[Law, Professional], litigation ~[Law, Professional],
+# salesbench-100 ~[Assistants, Professional], ledgerbench-100 ~[Finance,
+# Professional] (source repo blobfishai/finance-world). When re-including,
+# also check whether counselbench-100 duplicates litigation (both 100
+# long-horizon legal-agent tasks) before listing both.
+- blobfishai/counselbench-100
+- blobfishai/ledgerbench-100
+- blobfishai/litigation
+- blobfishai/salesbench-100
+# TEMPORARILY excluded (would otherwise be kept): canonical org upload of the
+# living Terminal-Bench-Science benchmark (70 tasks,
+# https://github.com/harbor-framework/terminal-bench-science) — distinct from
+# the google-deepmind/terminal-bench-science 52-task pinned snapshot, which
+# stays listed. Fails to load: inspect_ai's ComposeConfig rejects pids_limit.
+# Re-include once supported (fix proposed upstream) with overrides:
+# categories ~[Science, Coding], function_name: terminal_bench_science (dedup,
+# no collision), title: Terminal-Bench-Science, repo above.
+- terminal-bench-science/terminal-bench-science

--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -137,3 +137,15 @@
 # mirror of standard Harbor datasets that doesn't contain this one. Revisit
 # if it is ever published as a real benchmark.
 - adameubanks/*
+# Verbatim duplicate of dbt-labs/ade-bench (identical 48 task inputs) by an
+# individual (User, not org), self-described as "ADE-Bench adapted to run
+# with Inspect Harbor on K8s" — the same derivative infra re-upload class as
+# titouanlne/*. Keep the canonical author org's dbt-labs/ade-bench.
+- tomseimandi/ade-bench
+# Personal staging/test uploads by a Terminal-Bench core maintainer (User,
+# not org), both carrying the canonical Terminal-Bench desc verbatim:
+# tb-test is a 1-sample upload test; tb4-preview ("TB4" preview, 66 tasks)
+# doesn't load (build.no_cache rejected by inspect_ai's ComposeConfig).
+# Canonical releases live under terminal-bench/. Revisit if a real personal
+# benchmark appears under this account.
+- ryanmarten/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -278,13 +278,24 @@ blobfishai/counselbench-100:
   categories: []
 
 blobfishai/devopsbench-100:
-  categories: []
+  categories:
+  - Coding
+  - Professional
+  title: DevOpsBench-100
+  repo: https://github.com/blobfishai/software-devops
 
 blobfishai/domainbench-24:
-  categories: []
+  categories:
+  - Assistants
+  - Professional
+  title: DomainBench-24
 
 blobfishai/factorybench-100:
-  categories: []
+  categories:
+  - Assistants
+  - Professional
+  title: FactoryBench-100
+  repo: https://github.com/blobfishai/factory-agent-simulation
 
 blobfishai/ledgerbench-100:
   categories: []
@@ -609,7 +620,12 @@ ivanleo/agent-search:
   desc: Agent answers Gemini API questions by querying an indexed documentation database.
 
 josancamon19/physician-bench:
-  categories: []
+  categories:
+  - Medicine
+  - Professional
+  title: PhysicianBench
+  repo: https://github.com/HealthRex/PhysicianBench
+  arxiv: https://arxiv.org/abs/2605.02240
 
 kgmon/deepsearchqa:
   categories:
@@ -893,12 +909,6 @@ rounakbende10/rh-swe-bench:
   title: RH SWE-bench
   repo: https://github.com/rounakbende10/rh-swe-bench
 
-ryanmarten/tb-test:
-  categories: []
-
-ryanmarten/tb4-preview:
-  categories: []
-
 satbench/satbench:
   categories:
   - Reasoning
@@ -1069,6 +1079,9 @@ terminal-bench-pro/terminal-bench-pro:
 
 terminal-bench-science/terminal-bench-science:
   categories: []
+  function_name: terminal_bench_science
+  title: Terminal-Bench-Science
+  repo: https://github.com/harbor-framework/terminal-bench-science
 
 terminal-bench/terminal-bench:
   categories:
@@ -1120,9 +1133,6 @@ tinycomputerai/bun-server-bench:
   categories:
   - Coding
   repo: https://github.com/tinycomputerai/bun-server-bench
-
-tomseimandi/ade-bench:
-  categories: []
 
 usaco/usaco:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -274,9 +274,6 @@ binary-audit/binary-audit:
   function_name: binary_audit
   title: BinaryAudit
 
-blobfishai/counselbench-100:
-  categories: []
-
 blobfishai/devopsbench-100:
   categories:
   - Coding
@@ -296,15 +293,6 @@ blobfishai/factorybench-100:
   - Professional
   title: FactoryBench-100
   repo: https://github.com/blobfishai/factory-agent-simulation
-
-blobfishai/ledgerbench-100:
-  categories: []
-
-blobfishai/litigation:
-  categories: []
-
-blobfishai/salesbench-100:
-  categories: []
 
 cais/swebenchpro:
   categories:
@@ -491,7 +479,7 @@ google-deepmind/terminal-bench-science:
   - Science
   - Coding
   repo: https://github.com/harbor-framework/terminal-bench-science
-  title: Terminal-Bench-Science
+  title: GDM-Terminal-Bench-Science
 
 gorilla/bfcl:
   categories:
@@ -1076,12 +1064,6 @@ terminal-bench-pro/terminal-bench-pro:
   function_name: terminal_bench_pro
   title: Terminal-Bench Pro
   featured: true
-
-terminal-bench-science/terminal-bench-science:
-  categories: []
-  function_name: terminal_bench_science
-  title: Terminal-Bench-Science
-  repo: https://github.com/harbor-framework/terminal-bench-science
 
 terminal-bench/terminal-bench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -274,6 +274,27 @@ binary-audit/binary-audit:
   function_name: binary_audit
   title: BinaryAudit
 
+blobfishai/counselbench-100:
+  categories: []
+
+blobfishai/devopsbench-100:
+  categories: []
+
+blobfishai/domainbench-24:
+  categories: []
+
+blobfishai/factorybench-100:
+  categories: []
+
+blobfishai/ledgerbench-100:
+  categories: []
+
+blobfishai/litigation:
+  categories: []
+
+blobfishai/salesbench-100:
+  categories: []
+
 cais/swebenchpro:
   categories:
   - Coding
@@ -587,6 +608,9 @@ ivanleo/agent-search:
   - Assistants
   desc: Agent answers Gemini API questions by querying an indexed documentation database.
 
+josancamon19/physician-bench:
+  categories: []
+
 kgmon/deepsearchqa:
   categories:
   - Knowledge
@@ -869,6 +893,12 @@ rounakbende10/rh-swe-bench:
   title: RH SWE-bench
   repo: https://github.com/rounakbende10/rh-swe-bench
 
+ryanmarten/tb-test:
+  categories: []
+
+ryanmarten/tb4-preview:
+  categories: []
+
 satbench/satbench:
   categories:
   - Reasoning
@@ -1037,6 +1067,9 @@ terminal-bench-pro/terminal-bench-pro:
   title: Terminal-Bench Pro
   featured: true
 
+terminal-bench-science/terminal-bench-science:
+  categories: []
+
 terminal-bench/terminal-bench:
   categories:
   - Coding
@@ -1087,6 +1120,9 @@ tinycomputerai/bun-server-bench:
   categories:
   - Coding
   repo: https://github.com/tinycomputerai/bun-server-bench
+
+tomseimandi/ade-bench:
+  categories: []
 
 usaco/usaco:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -273,6 +273,55 @@
   version: latest
   categories:
   - Cybersecurity
+- title: blobfishai/counselbench-100
+  path: registry/blobfishai_counselbench_100.html
+  desc: 100 high-level legal-agent tasks with 97-asset multi-provider evidence rooms, distinct deep trajectories, and native causal state verification.
+  desc_trunc: 100 high-level legal-agent tasks with 97-asset multi-provider evidence rooms, distinct deep traject…
+  task_function: blobfishai_counselbench_100
+  samples: 100
+  version: latest
+- title: blobfishai/devopsbench-100
+  path: registry/blobfishai_devopsbench_100.html
+  desc: 100 deterministic long-horizon DevOps/SRE agent tasks over an executable NovaCart world with 32-67 call reference trajectories and state-diff vcode verifiers.
+  desc_trunc: 100 deterministic long-horizon DevOps/SRE agent tasks over an executable NovaCart world with 32-67…
+  task_function: blobfishai_devopsbench_100
+  samples: 100
+  version: latest
+- title: blobfishai/domainbench-24
+  path: registry/blobfishai_domainbench_24.html
+  desc: 24 deeply realistic stateful MCP tasks across six enterprise domains.
+  desc_trunc: 24 deeply realistic stateful MCP tasks across six enterprise domains.
+  task_function: blobfishai_domainbench_24
+  samples: 24
+  version: latest
+- title: blobfishai/factorybench-100
+  path: registry/blobfishai_factorybench_100.html
+  desc: 100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading.
+  desc_trunc: 100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading.
+  task_function: blobfishai_factorybench_100
+  samples: 100
+  version: latest
+- title: blobfishai/ledgerbench-100
+  path: registry/blobfishai_ledgerbench_100.html
+  desc: '100 causal corporate-finance workflows over a closed ERP sandbox: provider-shaped MCP tools, distributed evidence, exact state transitions, and no LLM judge.'
+  desc_trunc: '100 causal corporate-finance workflows over a closed ERP sandbox: provider-shaped MCP tools, distri…'
+  task_function: blobfishai_ledgerbench_100
+  samples: 100
+  version: latest
+- title: blobfishai/litigation
+  path: registry/blobfishai_litigation.html
+  desc: Executable litigation environments for agent training and evaluation. 100 long-horizon tasks, a median of 108 verified tool-calling steps each, worked across eight systems of record (Clio Manage, iManage Work, CM/ECF, Google Calendar, Docusign, Relativity, CourtListener and nine litigation sub-systems). Graded by deterministic state-diff and trace assertions — no LLM judge on the reward path.
+  desc_trunc: Executable litigation environments for agent training and evaluation. 100 long-horizon tasks, a med…
+  task_function: blobfishai_litigation
+  samples: 100
+  version: latest
+- title: blobfishai/salesbench-100
+  path: registry/blobfishai_salesbench_100.html
+  desc: 100 high-level sales operations requests with evidence-determined multi-system trajectories.
+  desc_trunc: 100 high-level sales operations requests with evidence-determined multi-system trajectories.
+  task_function: blobfishai_salesbench_100
+  samples: 100
+  version: latest
 - title: cais/swebenchpro
   path: registry/cais_swebenchpro.html
   desc: SWE-bench Pro with anti-exploitation (git history isolation + GitHub network blocking). 731 tasks, Python/JS/TS/Go.
@@ -659,6 +708,13 @@
   categories:
   - Coding
   - Assistants
+- title: josancamon19/physician-bench
+  path: registry/josancamon19_physician_bench.html
+  desc: Harbor packaging of the 100 Apache-2.0 HealthRex PhysicianBench tasks. Runtime requires separately authorized access to the fhir-full:v1 EHR image from Stanford Redivis.
+  desc_trunc: Harbor packaging of the 100 Apache-2.0 HealthRex PhysicianBench tasks. Runtime requires separately…
+  task_function: josancamon19_physician_bench
+  samples: 100
+  version: latest
 - title: kgmon/deepsearchqa
   path: registry/kgmon_deepsearchqa.html
   desc: DeepSearchQA is a 900-prompt factuality benchmark from Google DeepMind for evaluating deep research agents on difficult multi-step information-seeking tasks.
@@ -981,6 +1037,20 @@
   version: latest
   categories:
   - Coding
+- title: ryanmarten/tb-test
+  path: registry/ryanmarten_tb_test.html
+  desc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
+  desc_trunc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
+  task_function: ryanmarten_tb_test
+  samples: 1
+  version: latest
+- title: ryanmarten/tb4-preview
+  path: registry/ryanmarten_tb4_preview.html
+  desc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
+  desc_trunc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
+  task_function: ryanmarten_tb4_preview
+  samples: 66
+  version: latest
 - title: satbench/satbench
   path: registry/satbench.html
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'
@@ -1166,7 +1236,7 @@
   desc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
   desc_trunc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
   task_function: terminal_bench
-  samples: 74
+  samples: 66
   version: latest
   categories:
   - Coding
@@ -1200,6 +1270,13 @@
   version: latest
   categories:
   - Coding
+- title: terminal-bench-science/terminal-bench-science
+  path: registry/terminal_bench_science_terminal_bench_science.html
+  desc: A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathematical, and engineering sciences.
+  desc_trunc: A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathem…
+  task_function: terminal_bench_science_terminal_bench_science
+  samples: 70
+  version: latest
 - title: theagentcompany/theagentcompany
   path: registry/theagentcompany.html
   desc: An agent benchmark with tasks in a simulated software company across GitLab, Plane, OwnCloud, and RocketChat services, evaluating LLM agents on real-world professional work.
@@ -1230,6 +1307,13 @@
   version: latest
   categories:
   - Coding
+- title: tomseimandi/ade-bench
+  path: registry/tomseimandi_ade_bench.html
+  desc: ADE-Bench adapted to run with Inspect Harbor on K8s.
+  desc_trunc: ADE-Bench adapted to run with Inspect Harbor on K8s.
+  task_function: tomseimandi_ade_bench
+  samples: 48
+  version: latest
 - title: usaco/usaco
   path: registry/usaco.html
   desc: 'USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -273,13 +273,6 @@
   version: latest
   categories:
   - Cybersecurity
-- title: blobfishai/counselbench-100
-  path: registry/blobfishai_counselbench_100.html
-  desc: 100 high-level legal-agent tasks with 97-asset multi-provider evidence rooms, distinct deep trajectories, and native causal state verification.
-  desc_trunc: 100 high-level legal-agent tasks with 97-asset multi-provider evidence rooms, distinct deep traject…
-  task_function: blobfishai_counselbench_100
-  samples: 100
-  version: latest
 - title: blobfishai/devopsbench-100
   path: registry/blobfishai_devopsbench_100.html
   desc: 100 deterministic long-horizon DevOps/SRE agent tasks over an executable NovaCart world with 32-67 call reference trajectories and state-diff vcode verifiers.
@@ -310,27 +303,6 @@
   categories:
   - Assistants
   - Professional
-- title: blobfishai/ledgerbench-100
-  path: registry/blobfishai_ledgerbench_100.html
-  desc: '100 causal corporate-finance workflows over a closed ERP sandbox: provider-shaped MCP tools, distributed evidence, exact state transitions, and no LLM judge.'
-  desc_trunc: '100 causal corporate-finance workflows over a closed ERP sandbox: provider-shaped MCP tools, distri…'
-  task_function: blobfishai_ledgerbench_100
-  samples: 100
-  version: latest
-- title: blobfishai/litigation
-  path: registry/blobfishai_litigation.html
-  desc: Executable litigation environments for agent training and evaluation. 100 long-horizon tasks, a median of 108 verified tool-calling steps each, worked across eight systems of record (Clio Manage, iManage Work, CM/ECF, Google Calendar, Docusign, Relativity, CourtListener and nine litigation sub-systems). Graded by deterministic state-diff and trace assertions — no LLM judge on the reward path.
-  desc_trunc: Executable litigation environments for agent training and evaluation. 100 long-horizon tasks, a med…
-  task_function: blobfishai_litigation
-  samples: 100
-  version: latest
-- title: blobfishai/salesbench-100
-  path: registry/blobfishai_salesbench_100.html
-  desc: 100 high-level sales operations requests with evidence-determined multi-system trajectories.
-  desc_trunc: 100 high-level sales operations requests with evidence-determined multi-system trajectories.
-  task_function: blobfishai_salesbench_100
-  samples: 100
-  version: latest
 - title: cais/swebenchpro
   path: registry/cais_swebenchpro.html
   desc: SWE-bench Pro with anti-exploitation (git history isolation + GitHub network blocking). 731 tasks, Python/JS/TS/Go.
@@ -1268,13 +1240,6 @@
   version: latest
   categories:
   - Coding
-- title: terminal-bench-science/terminal-bench-science
-  path: registry/terminal_bench_science.html
-  desc: A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathematical, and engineering sciences.
-  desc_trunc: A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathem…
-  task_function: terminal_bench_science
-  samples: 70
-  version: latest
 - title: theagentcompany/theagentcompany
   path: registry/theagentcompany.html
   desc: An agent benchmark with tasks in a simulated software company across GitLab, Plane, OwnCloud, and RocketChat services, evaluating LLM agents on real-world professional work.

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -287,6 +287,9 @@
   task_function: blobfishai_devopsbench_100
   samples: 100
   version: latest
+  categories:
+  - Coding
+  - Professional
 - title: blobfishai/domainbench-24
   path: registry/blobfishai_domainbench_24.html
   desc: 24 deeply realistic stateful MCP tasks across six enterprise domains.
@@ -294,6 +297,9 @@
   task_function: blobfishai_domainbench_24
   samples: 24
   version: latest
+  categories:
+  - Assistants
+  - Professional
 - title: blobfishai/factorybench-100
   path: registry/blobfishai_factorybench_100.html
   desc: 100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading.
@@ -301,6 +307,9 @@
   task_function: blobfishai_factorybench_100
   samples: 100
   version: latest
+  categories:
+  - Assistants
+  - Professional
 - title: blobfishai/ledgerbench-100
   path: registry/blobfishai_ledgerbench_100.html
   desc: '100 causal corporate-finance workflows over a closed ERP sandbox: provider-shaped MCP tools, distributed evidence, exact state transitions, and no LLM judge.'
@@ -715,6 +724,9 @@
   task_function: josancamon19_physician_bench
   samples: 100
   version: latest
+  categories:
+  - Medicine
+  - Professional
 - title: kgmon/deepsearchqa
   path: registry/kgmon_deepsearchqa.html
   desc: DeepSearchQA is a 900-prompt factuality benchmark from Google DeepMind for evaluating deep research agents on difficult multi-step information-seeking tasks.
@@ -1037,20 +1049,6 @@
   version: latest
   categories:
   - Coding
-- title: ryanmarten/tb-test
-  path: registry/ryanmarten_tb_test.html
-  desc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
-  desc_trunc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
-  task_function: ryanmarten_tb_test
-  samples: 1
-  version: latest
-- title: ryanmarten/tb4-preview
-  path: registry/ryanmarten_tb4_preview.html
-  desc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
-  desc_trunc: Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
-  task_function: ryanmarten_tb4_preview
-  samples: 66
-  version: latest
 - title: satbench/satbench
   path: registry/satbench.html
   desc: 'SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.'
@@ -1271,10 +1269,10 @@
   categories:
   - Coding
 - title: terminal-bench-science/terminal-bench-science
-  path: registry/terminal_bench_science_terminal_bench_science.html
+  path: registry/terminal_bench_science.html
   desc: A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathematical, and engineering sciences.
   desc_trunc: A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathem…
-  task_function: terminal_bench_science_terminal_bench_science
+  task_function: terminal_bench_science
   samples: 70
   version: latest
 - title: theagentcompany/theagentcompany
@@ -1307,13 +1305,6 @@
   version: latest
   categories:
   - Coding
-- title: tomseimandi/ade-bench
-  path: registry/tomseimandi_ade_bench.html
-  desc: ADE-Bench adapted to run with Inspect Harbor on K8s.
-  desc_trunc: ADE-Bench adapted to run with Inspect Harbor on K8s.
-  task_function: tomseimandi_ade_bench
-  samples: 48
-  version: latest
 - title: usaco/usaco
   path: registry/usaco.html
   desc: 'USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -881,6 +881,223 @@ def binary_audit(
 
 
 @task
+def blobfishai_counselbench_100(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 high-level legal-agent tasks with 97-asset multi-provider evidence rooms, distinct deep trajectories, and native causal state verification.
+
+    Slug: blobfishai/counselbench-100
+    Latest digest: sha256:0e2b7e78bbde84c1691ad016f7b2344e5570b98b5545a33ef783a0687e60b6e8
+    """
+    return _harbor_base(
+        package_name="blobfishai/counselbench-100",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_devopsbench_100(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 deterministic long-horizon DevOps/SRE agent tasks over an executable NovaCart world with 32-67 call reference trajectories and state-diff vcode verifiers.
+
+    Slug: blobfishai/devopsbench-100
+    Latest digest: sha256:1e2c1afe4ce49717a2ad2bda0cc0cbfa9bcc4fab3d2d96a93507be88f3571614
+    """
+    return _harbor_base(
+        package_name="blobfishai/devopsbench-100",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_domainbench_24(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""24 deeply realistic stateful MCP tasks across six enterprise domains
+
+    Slug: blobfishai/domainbench-24
+    Latest digest: sha256:c3f89005c548148c27dc4fe9836eb8a65571788ca8a5567ff6208405cc730078
+    """
+    return _harbor_base(
+        package_name="blobfishai/domainbench-24",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_factorybench_100(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading
+
+    Slug: blobfishai/factorybench-100
+    Latest digest: sha256:f77fcb2c0b8e4ba9a64a7656baeb6928b4efbb16a760a698506efb86340ffe72
+    """
+    return _harbor_base(
+        package_name="blobfishai/factorybench-100",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_ledgerbench_100(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 causal corporate-finance workflows over a closed ERP sandbox: provider-shaped MCP tools, distributed evidence, exact state transitions, and no LLM judge.
+
+    Slug: blobfishai/ledgerbench-100
+    Latest digest: sha256:5e685691b3032c91489b8098947a08faabe9da131f6140c2ac54e1ac0092f693
+    """
+    return _harbor_base(
+        package_name="blobfishai/ledgerbench-100",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_litigation(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Executable litigation environments for agent training and evaluation. 100 long-horizon tasks, a median of 108 verified tool-calling steps each, worked across eight systems of record (Clio Manage, iManage Work, CM/ECF, Google Calendar, Docusign, Relativity, CourtListener and nine litigation sub-systems). Graded by deterministic state-diff and trace assertions — no LLM judge on the reward path.
+
+    Slug: blobfishai/litigation
+    Latest digest: sha256:53d0cd3433b743c42671d10ef1b4de874c447b4994020f702cb5a31e7bf1ba0c
+    """
+    return _harbor_base(
+        package_name="blobfishai/litigation",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_salesbench_100(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 high-level sales operations requests with evidence-determined multi-system trajectories.
+
+    Slug: blobfishai/salesbench-100
+    Latest digest: sha256:1aafe58cb4a5578a8f5f2931f175e834dae8b83d7cf65b6a96e9e6dacaf59623
+    """
+    return _harbor_base(
+        package_name="blobfishai/salesbench-100",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def cais_swebenchpro(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2121,6 +2338,37 @@ def ivanleo_agent_search(
 
 
 @task
+def josancamon19_physician_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Harbor packaging of the 100 Apache-2.0 HealthRex PhysicianBench tasks. Runtime requires separately authorized access to the fhir-full:v1 EHR image from Stanford Redivis.
+
+    Slug: josancamon19/physician-bench
+    Latest digest: sha256:665cad8a072424b2e0c02d2f0b5dbe8e9e53dcce82bb5b7ae2215553c673cf01
+    """
+    return _harbor_base(
+        package_name="josancamon19/physician-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def kgmon_deepsearchqa(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2414,7 +2662,7 @@ def luosuu_swe_kokkos_bench(
     r"""100 verified SWE-bench-style coding tasks from the Kokkos ecosystem
 
     Slug: luosuu/SWE-kokkos-bench
-    Latest digest: sha256:06ec838d37e2c05499b298648fb0e5ad1e231213472016e7b1298c4c6d7d3649
+    Latest digest: sha256:4313f853a5bca4eeee18ece6928d5cb2c87403f9ab7be992f87d602e683bf2c5
     """
     return _harbor_base(
         package_name="luosuu/SWE-kokkos-bench",
@@ -3181,6 +3429,68 @@ def rounakbende10_rh_swe_bench(
 
 
 @task
+def ryanmarten_tb_test(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
+
+    Slug: ryanmarten/tb-test
+    Latest digest: sha256:08f1953059ee4071a21a79297190026a55d6f035c6dca58eb93ad14e1a3a1119
+    """
+    return _harbor_base(
+        package_name="ryanmarten/tb-test",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def ryanmarten_tb4_preview(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
+
+    Slug: ryanmarten/tb4-preview
+    Latest digest: sha256:83eaa67687df96f53b801a0fa6773b0b82876372c5926d80b6be30957b8422a0
+    """
+    return _harbor_base(
+        package_name="ryanmarten/tb4-preview",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def satbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3784,7 +4094,7 @@ def terminal_bench(
     r"""Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
 
     Slug: terminal-bench/terminal-bench
-    Latest digest: sha256:a32a61879ea94eb9dc16fa1fbeb398759f0c07ca633d9d1f6aec760207036da3
+    Latest digest: sha256:39d9f44b40420cde8fdcc087579c0d72a7e14fa3656d603c3f0d22fb35e27732
     """
     return _harbor_base(
         package_name="terminal-bench/terminal-bench",
@@ -3894,6 +4204,37 @@ def terminal_bench_pro(
 
 
 @task
+def terminal_bench_science_terminal_bench_science(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathematical, and engineering sciences.
+
+    Slug: terminal-bench-science/terminal-bench-science
+    Latest digest: sha256:91531bf50016a7c64f6cc60794a17c64c6b2c14858a8ae0de39ca16f2abd611a
+    """
+    return _harbor_base(
+        package_name="terminal-bench-science/terminal-bench-science",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def theagentcompany(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -3974,6 +4315,37 @@ def tinycomputerai_bun_server_bench(
     """
     return _harbor_base(
         package_name="tinycomputerai/bun-server-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def tomseimandi_ade_bench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""ADE-Bench adapted to run with Inspect Harbor on K8s
+
+    Slug: tomseimandi/ade-bench
+    Latest digest: sha256:f3e5003605edc18603e1b5f71cb7a15f6749a413e8acc78ac0c8b3b49a561d06
+    """
+    return _harbor_base(
+        package_name="tomseimandi/ade-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3429,68 +3429,6 @@ def rounakbende10_rh_swe_bench(
 
 
 @task
-def ryanmarten_tb_test(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
-
-    Slug: ryanmarten/tb-test
-    Latest digest: sha256:08f1953059ee4071a21a79297190026a55d6f035c6dca58eb93ad14e1a3a1119
-    """
-    return _harbor_base(
-        package_name="ryanmarten/tb-test",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def ryanmarten_tb4_preview(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Terminal-Bench is a benchmark for measuring agents' abilities to complete tasks using a terminal.
-
-    Slug: ryanmarten/tb4-preview
-    Latest digest: sha256:83eaa67687df96f53b801a0fa6773b0b82876372c5926d80b6be30957b8422a0
-    """
-    return _harbor_base(
-        package_name="ryanmarten/tb4-preview",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def satbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -4204,7 +4142,7 @@ def terminal_bench_pro(
 
 
 @task
-def terminal_bench_science_terminal_bench_science(
+def terminal_bench_science(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
     dataset_exclude_task_names: list[str] | None = None,
@@ -4315,37 +4253,6 @@ def tinycomputerai_bun_server_bench(
     """
     return _harbor_base(
         package_name="tinycomputerai/bun-server-bench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def tomseimandi_ade_bench(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""ADE-Bench adapted to run with Inspect Harbor on K8s
-
-    Slug: tomseimandi/ade-bench
-    Latest digest: sha256:f3e5003605edc18603e1b5f71cb7a15f6749a413e8acc78ac0c8b3b49a561d06
-    """
-    return _harbor_base(
-        package_name="tomseimandi/ade-bench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -881,37 +881,6 @@ def binary_audit(
 
 
 @task
-def blobfishai_counselbench_100(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""100 high-level legal-agent tasks with 97-asset multi-provider evidence rooms, distinct deep trajectories, and native causal state verification.
-
-    Slug: blobfishai/counselbench-100
-    Latest digest: sha256:0e2b7e78bbde84c1691ad016f7b2344e5570b98b5545a33ef783a0687e60b6e8
-    """
-    return _harbor_base(
-        package_name="blobfishai/counselbench-100",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def blobfishai_devopsbench_100(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -926,7 +895,7 @@ def blobfishai_devopsbench_100(
     r"""100 deterministic long-horizon DevOps/SRE agent tasks over an executable NovaCart world with 32-67 call reference trajectories and state-diff vcode verifiers.
 
     Slug: blobfishai/devopsbench-100
-    Latest digest: sha256:1e2c1afe4ce49717a2ad2bda0cc0cbfa9bcc4fab3d2d96a93507be88f3571614
+    Latest digest: sha256:1efd654cd3248d225964702c8b4c6f7c9f3909a557b7a9c64eee91642e12efce
     """
     return _harbor_base(
         package_name="blobfishai/devopsbench-100",
@@ -988,103 +957,10 @@ def blobfishai_factorybench_100(
     r"""100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading
 
     Slug: blobfishai/factorybench-100
-    Latest digest: sha256:f77fcb2c0b8e4ba9a64a7656baeb6928b4efbb16a760a698506efb86340ffe72
+    Latest digest: sha256:bca3817fd59796be8ba350900f0efd9538c086a22033d27d0f06c3275208fed9
     """
     return _harbor_base(
         package_name="blobfishai/factorybench-100",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def blobfishai_ledgerbench_100(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""100 causal corporate-finance workflows over a closed ERP sandbox: provider-shaped MCP tools, distributed evidence, exact state transitions, and no LLM judge.
-
-    Slug: blobfishai/ledgerbench-100
-    Latest digest: sha256:5e685691b3032c91489b8098947a08faabe9da131f6140c2ac54e1ac0092f693
-    """
-    return _harbor_base(
-        package_name="blobfishai/ledgerbench-100",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def blobfishai_litigation(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Executable litigation environments for agent training and evaluation. 100 long-horizon tasks, a median of 108 verified tool-calling steps each, worked across eight systems of record (Clio Manage, iManage Work, CM/ECF, Google Calendar, Docusign, Relativity, CourtListener and nine litigation sub-systems). Graded by deterministic state-diff and trace assertions — no LLM judge on the reward path.
-
-    Slug: blobfishai/litigation
-    Latest digest: sha256:53d0cd3433b743c42671d10ef1b4de874c447b4994020f702cb5a31e7bf1ba0c
-    """
-    return _harbor_base(
-        package_name="blobfishai/litigation",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def blobfishai_salesbench_100(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""100 high-level sales operations requests with evidence-determined multi-system trajectories.
-
-    Slug: blobfishai/salesbench-100
-    Latest digest: sha256:1aafe58cb4a5578a8f5f2931f175e834dae8b83d7cf65b6a96e9e6dacaf59623
-    """
-    return _harbor_base(
-        package_name="blobfishai/salesbench-100",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -2662,7 +2538,7 @@ def luosuu_swe_kokkos_bench(
     r"""100 verified SWE-bench-style coding tasks from the Kokkos ecosystem
 
     Slug: luosuu/SWE-kokkos-bench
-    Latest digest: sha256:4313f853a5bca4eeee18ece6928d5cb2c87403f9ab7be992f87d602e683bf2c5
+    Latest digest: sha256:a6e1e95fad48ad9ddf49a6e7d4605f2ff5e38f2f6b5aa6bf8fa4288a2385bef2
     """
     return _harbor_base(
         package_name="luosuu/SWE-kokkos-bench",
@@ -4129,37 +4005,6 @@ def terminal_bench_pro(
     """
     return _harbor_base(
         package_name="terminal-bench-pro/terminal-bench-pro",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def terminal_bench_science(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""A benchmark for evaluating AI agents on research workflows across the life, physical, earth, mathematical, and engineering sciences.
-
-    Slug: terminal-bench-science/terminal-bench-science
-    Latest digest: sha256:91531bf50016a7c64f6cc60794a17c64c6b2c14858a8ae0de39ca16f2abd611a
-    """
-    return _harbor_base(
-        package_name="terminal-bench-science/terminal-bench-science",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
blobfishai/counselbench-100
blobfishai/devopsbench-100
blobfishai/domainbench-24
blobfishai/factorybench-100
blobfishai/ledgerbench-100
blobfishai/litigation
blobfishai/salesbench-100
josancamon19/physician-bench
ryanmarten/tb-test
ryanmarten/tb4-preview
terminal-bench-science/terminal-bench-science
tomseimandi/ade-bench
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks