### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -172,3 +172,10 @@
 # categories ~[Science, Coding], function_name: terminal_bench_science (dedup,
 # no collision), title: Terminal-Bench-Science, repo above.
 - terminal-bench-science/terminal-bench-science
+# TEMPORARILY excluded (would otherwise be kept): 87 CTF tasks curated from
+# the AlibabaCTF competition series by the Alibaba-AAIG org (a real
+# Organization) — fails to load because inspect_ai's ComposeConfig rejects
+# the `cgroup` service key (one task uses it). Re-include once supported
+# (fix proposed upstream in inspect_ai PR #5139) with overrides:
+# categories ~[Cybersecurity], title: AlibabaCTF.
+- alibaba-aaig/alibaba-ctf

--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -179,3 +179,13 @@
 # (fix proposed upstream in inspect_ai PR #5139) with overrides:
 # categories ~[Cybersecurity], title: AlibabaCTF.
 - alibaba-aaig/alibaba-ctf
+# TEMPORARILY excluded (would otherwise be kept): the verified 40-task split
+# of ORCA-bench (root-cause analysis of oncall incidents), uploaded by the
+# same canonical org as the listed orca-bench/orca-bench — fails to load
+# because inspect_ai's ComposeConfig rejects `stop_grace_period` (all its
+# compose files use it). Re-include once supported (fix proposed upstream in
+# inspect_ai PR #5139) with overrides mirroring the sibling: categories
+# ~[Coding, Professional], function_name: orca_bench_verified (dedup, no
+# collision), title: ORCA-bench Verified, repo orca-bench/ORCA-bench,
+# arxiv 2607.28545, and a desc override trimming the dangling "please see."
+- orca-bench/orca-bench-verified

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -198,9 +198,6 @@ algotune/algotune:
   function_name: algotune
   title: AlgoTune
 
-alibaba-aaig/alibaba-ctf:
-  categories: []
-
 android-bench/android-bench:
   categories:
   - Coding
@@ -278,7 +275,11 @@ binary-audit/binary-audit:
   title: BinaryAudit
 
 blobfishai/dealbench-100-suite:
-  categories: []
+  categories:
+  - Finance
+  - Professional
+  title: DealBench-100 Suite
+  repo: https://github.com/blobfishai/deal-agent-simulation
 
 blobfishai/devopsbench-100:
   categories:
@@ -294,7 +295,11 @@ blobfishai/domainbench-24:
   title: DomainBench-24
 
 blobfishai/erpbench-100-suite:
-  categories: []
+  categories:
+  - Finance
+  - Professional
+  title: ERPBench-100 Suite
+  repo: https://github.com/blobfishai/erp-agent-simulation
 
 blobfishai/factorybench-100:
   categories:
@@ -302,6 +307,9 @@ blobfishai/factorybench-100:
   - Professional
   title: FactoryBench-100
   repo: https://github.com/blobfishai/factory-agent-simulation
+
+blobfishai/hubbench:
+  categories: []
 
 cais/swebenchpro:
   categories:
@@ -687,6 +695,9 @@ lcb/longswebench-32k:
   repo: https://github.com/Zteefano/long-code-bench
   title: LongSWE-Bench (32k)
 
+lica-world/gdb:
+  categories: []
+
 livecodebench/livecodebench:
   categories:
   - Coding
@@ -800,6 +811,9 @@ orca-bench/orca-bench:
   arxiv: https://arxiv.org/abs/2607.28545
   desc: 'ORCA-bench: root-cause analysis of oncall incidents — agents investigate telemetry from an instrumented microservices system to diagnose each incident; public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard).'
   title: ORCA-bench
+
+orca-bench/orca-bench-verified:
+  categories: []
 
 orinlabs/horizon-public:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -198,6 +198,9 @@ algotune/algotune:
   function_name: algotune
   title: AlgoTune
 
+alibaba-aaig/alibaba-ctf:
+  categories: []
+
 android-bench/android-bench:
   categories:
   - Coding
@@ -274,6 +277,9 @@ binary-audit/binary-audit:
   function_name: binary_audit
   title: BinaryAudit
 
+blobfishai/dealbench-100-suite:
+  categories: []
+
 blobfishai/devopsbench-100:
   categories:
   - Coding
@@ -286,6 +292,9 @@ blobfishai/domainbench-24:
   - Assistants
   - Professional
   title: DomainBench-24
+
+blobfishai/erpbench-100-suite:
+  categories: []
 
 blobfishai/factorybench-100:
   categories:
@@ -677,15 +686,6 @@ lcb/longswebench-32k:
   arxiv: https://arxiv.org/abs/2505.07897
   repo: https://github.com/Zteefano/long-code-bench
   title: LongSWE-Bench (32k)
-
-lica-world/gdb:
-  categories:
-  - Multimodal
-  - Professional
-  arxiv: https://arxiv.org/abs/2604.04192
-  repo: https://github.com/purvanshi-lica/lica-bench
-  desc: 'GraphicDesignBench (GDB): evaluating AI on graphic design tasks across layout, typography, infographics, template design, and animation.'
-  title: GraphicDesignBench
 
 livecodebench/livecodebench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -309,7 +309,11 @@ blobfishai/factorybench-100:
   repo: https://github.com/blobfishai/factory-agent-simulation
 
 blobfishai/hubbench:
-  categories: []
+  categories:
+  - Assistants
+  - Professional
+  title: HubBench
+  repo: https://github.com/blobfishai/hub-agent-simulation
 
 cais/swebenchpro:
   categories:
@@ -696,7 +700,11 @@ lcb/longswebench-32k:
   title: LongSWE-Bench (32k)
 
 lica-world/gdb:
-  categories: []
+  categories:
+  - Multimodal
+  - Professional
+  title: GraphicDesignBench
+  repo: https://github.com/lica-world/GDB
 
 livecodebench/livecodebench:
   categories:
@@ -811,9 +819,6 @@ orca-bench/orca-bench:
   arxiv: https://arxiv.org/abs/2607.28545
   desc: 'ORCA-bench: root-cause analysis of oncall incidents — agents investigate telemetry from an instrumented microservices system to diagnose each incident; public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard).'
   title: ORCA-bench
-
-orca-bench/orca-bench-verified:
-  categories: []
 
 orinlabs/horizon-public:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -187,13 +187,6 @@
   version: latest
   categories:
   - Coding
-- title: alibaba-aaig/alibaba-ctf
-  path: registry/alibaba_aaig_alibaba_ctf.html
-  desc: A dataset of 87 Capture-The-Flag tasks curated from the AlibabaCTF competition series (2023-2026) for evaluating agents on offensive security work.
-  desc_trunc: A dataset of 87 Capture-The-Flag tasks curated from the AlibabaCTF competition series (2023-2026) f…
-  task_function: alibaba_aaig_alibaba_ctf
-  samples: 87
-  version: latest
 - title: android-bench/android-bench
   path: registry/android_bench.html
   desc: A dataset of 100 Android software engineering tasks derived from real-world repositories.
@@ -287,6 +280,9 @@
   task_function: blobfishai_dealbench_100_suite
   samples: 100
   version: latest
+  categories:
+  - Finance
+  - Professional
 - title: blobfishai/devopsbench-100
   path: registry/blobfishai_devopsbench_100.html
   desc: 100 deterministic long-horizon DevOps/SRE agent tasks over an executable NovaCart world with 32-67 call reference trajectories and state-diff vcode verifiers.
@@ -314,6 +310,9 @@
   task_function: blobfishai_erpbench_100_suite
   samples: 100
   version: latest
+  categories:
+  - Finance
+  - Professional
 - title: blobfishai/factorybench-100
   path: registry/blobfishai_factorybench_100.html
   desc: 100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading.
@@ -324,6 +323,13 @@
   categories:
   - Assistants
   - Professional
+- title: blobfishai/hubbench
+  path: registry/blobfishai_hubbench.html
+  desc: 'HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub professional-domain cluster — 96 stateful multi-system employee-decision tasks over isolated SQLite worlds (HubScore, no LLM judge).'
+  desc_trunc: 'HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub prof…'
+  task_function: blobfishai_hubbench
+  samples: 96
+  version: latest
 - title: cais/swebenchpro
   path: registry/cais_swebenchpro.html
   desc: SWE-bench Pro with anti-exploitation (git history isolation + GitHub network blocking). 731 tasks, Python/JS/TS/Go.
@@ -787,6 +793,13 @@
   version: latest
   categories:
   - Coding
+- title: lica-world/gdb
+  path: registry/lica_world_gdb.html
+  desc: Full GraphicDesignBench (GDB) benchmark converted to Harbor tasks.
+  desc_trunc: Full GraphicDesignBench (GDB) benchmark converted to Harbor tasks.
+  task_function: lica_world_gdb
+  samples: 33786
+  version: latest
 - title: livecodebench/livecodebench
   path: registry/livecodebench.html
   desc: 'LiveCodeBench: contamination-free coding benchmark continuously collected from LeetCode, AtCoder, and Codeforces, supporting code generation, self-repair, execution, and test-output prediction.'
@@ -920,6 +933,13 @@
   categories:
   - Coding
   - Professional
+- title: orca-bench/orca-bench-verified
+  path: registry/orca_bench_orca_bench_verified.html
+  desc: An agent benchmark for root cause analysis — verified split of 40 tasks across 40 incidents (10 easy, 15 medium, 15 hard). For the results on all 1,079 tasks, please see.
+  desc_trunc: An agent benchmark for root cause analysis — verified split of 40 tasks across 40 incidents (10 eas…
+  task_function: orca_bench_orca_bench_verified
+  samples: 40
+  version: latest
 - title: orinlabs/horizon-public
   path: registry/orinlabs_horizon_public.html
   desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -187,6 +187,13 @@
   version: latest
   categories:
   - Coding
+- title: alibaba-aaig/alibaba-ctf
+  path: registry/alibaba_aaig_alibaba_ctf.html
+  desc: A dataset of 87 Capture-The-Flag tasks curated from the AlibabaCTF competition series (2023-2026) for evaluating agents on offensive security work.
+  desc_trunc: A dataset of 87 Capture-The-Flag tasks curated from the AlibabaCTF competition series (2023-2026) f…
+  task_function: alibaba_aaig_alibaba_ctf
+  samples: 87
+  version: latest
 - title: android-bench/android-bench
   path: registry/android_bench.html
   desc: A dataset of 100 Android software engineering tasks derived from real-world repositories.
@@ -273,6 +280,13 @@
   version: latest
   categories:
   - Cybersecurity
+- title: blobfishai/dealbench-100-suite
+  path: registry/blobfishai_dealbench_100_suite.html
+  desc: 100 executable investment-banking workflows with deterministic DealScore grading.
+  desc_trunc: 100 executable investment-banking workflows with deterministic DealScore grading.
+  task_function: blobfishai_dealbench_100_suite
+  samples: 100
+  version: latest
 - title: blobfishai/devopsbench-100
   path: registry/blobfishai_devopsbench_100.html
   desc: 100 deterministic long-horizon DevOps/SRE agent tasks over an executable NovaCart world with 32-67 call reference trajectories and state-diff vcode verifiers.
@@ -293,6 +307,13 @@
   categories:
   - Assistants
   - Professional
+- title: blobfishai/erpbench-100-suite
+  path: registry/blobfishai_erpbench_100_suite.html
+  desc: 100 executable Oracle-Fusion-shaped ERP workflows with deterministic ERPScore grading.
+  desc_trunc: 100 executable Oracle-Fusion-shaped ERP workflows with deterministic ERPScore grading.
+  task_function: blobfishai_erpbench_100_suite
+  samples: 100
+  version: latest
 - title: blobfishai/factorybench-100
   path: registry/blobfishai_factorybench_100.html
   desc: 100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading.
@@ -766,16 +787,6 @@
   version: latest
   categories:
   - Coding
-- title: lica-world/gdb
-  path: registry/lica_world_gdb.html
-  desc: 'GraphicDesignBench (GDB): evaluating AI on graphic design tasks across layout, typography, infographics, template design, and animation.'
-  desc_trunc: 'GraphicDesignBench (GDB): evaluating AI on graphic design tasks across layout, typography, infograp…'
-  task_function: lica_world_gdb
-  samples: 33786
-  version: latest
-  categories:
-  - Multimodal
-  - Professional
 - title: livecodebench/livecodebench
   path: registry/livecodebench.html
   desc: 'LiveCodeBench: contamination-free coding benchmark continuously collected from LeetCode, AtCoder, and Codeforces, supporting code generation, self-repair, execution, and test-output prediction.'

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -330,6 +330,9 @@
   task_function: blobfishai_hubbench
   samples: 96
   version: latest
+  categories:
+  - Assistants
+  - Professional
 - title: cais/swebenchpro
   path: registry/cais_swebenchpro.html
   desc: SWE-bench Pro with anti-exploitation (git history isolation + GitHub network blocking). 731 tasks, Python/JS/TS/Go.
@@ -800,6 +803,9 @@
   task_function: lica_world_gdb
   samples: 33786
   version: latest
+  categories:
+  - Multimodal
+  - Professional
 - title: livecodebench/livecodebench
   path: registry/livecodebench.html
   desc: 'LiveCodeBench: contamination-free coding benchmark continuously collected from LeetCode, AtCoder, and Codeforces, supporting code generation, self-repair, execution, and test-output prediction.'
@@ -933,13 +939,6 @@
   categories:
   - Coding
   - Professional
-- title: orca-bench/orca-bench-verified
-  path: registry/orca_bench_orca_bench_verified.html
-  desc: An agent benchmark for root cause analysis — verified split of 40 tasks across 40 incidents (10 easy, 15 medium, 15 hard). For the results on all 1,079 tasks, please see.
-  desc_trunc: An agent benchmark for root cause analysis — verified split of 40 tasks across 40 incidents (10 eas…
-  task_function: orca_bench_orca_bench_verified
-  samples: 40
-  version: latest
 - title: orinlabs/horizon-public
   path: registry/orinlabs_horizon_public.html
   desc: 'Horizon: public example subset of a learning benchmark for extremely long-horizon agents — the agent must acquire knowledge from a long first-person session history and apply it to resolve a later request in the environment.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -3020,37 +3020,6 @@ def orca_bench(
 
 
 @task
-def orca_bench_orca_bench_verified(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""An agent benchmark for root cause analysis — verified split of 40 tasks across 40 incidents (10 easy, 15 medium, 15 hard). For the results on all 1,079 tasks, please see https://arxiv.org/abs/2607.28545.
-
-    Slug: orca-bench/orca-bench-verified
-    Latest digest: sha256:263a25d01329e4409bc03bfcd9e6d9771d189f6060a4b2db831b5e89783f7162
-    """
-    return _harbor_base(
-        package_name="orca-bench/orca-bench-verified",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def orinlabs_horizon_public(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -602,6 +602,37 @@ def algotune(
 
 
 @task
+def alibaba_aaig_alibaba_ctf(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""A dataset of 87 Capture-The-Flag tasks curated from the AlibabaCTF competition series (2023-2026) for evaluating agents on offensive security work.
+
+    Slug: alibaba-aaig/alibaba-ctf
+    Latest digest: sha256:9d50ae96f650f75d66a797a9a0ebfab8f5456edac8cc790d416b03356c032f16
+    """
+    return _harbor_base(
+        package_name="alibaba-aaig/alibaba-ctf",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def android_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -881,6 +912,37 @@ def binary_audit(
 
 
 @task
+def blobfishai_dealbench_100_suite(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 executable investment-banking workflows with deterministic DealScore grading
+
+    Slug: blobfishai/dealbench-100-suite
+    Latest digest: sha256:9f8b2d24a04cc39a3bbc75a10ec9eb22ffd406851480b47850799f607b4d74b6
+    """
+    return _harbor_base(
+        package_name="blobfishai/dealbench-100-suite",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def blobfishai_devopsbench_100(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -943,6 +1005,37 @@ def blobfishai_domainbench_24(
 
 
 @task
+def blobfishai_erpbench_100_suite(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 executable Oracle-Fusion-shaped ERP workflows with deterministic ERPScore grading
+
+    Slug: blobfishai/erpbench-100-suite
+    Latest digest: sha256:26648e276ee6e190c73c343bf93cf77823718c9c565f7d92a330b4ddbe5fdc56
+    """
+    return _harbor_base(
+        package_name="blobfishai/erpbench-100-suite",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def blobfishai_factorybench_100(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -957,7 +1050,7 @@ def blobfishai_factorybench_100(
     r"""100 executable manufacturing ERP workflow tasks with deterministic FactoryScore grading
 
     Slug: blobfishai/factorybench-100
-    Latest digest: sha256:bca3817fd59796be8ba350900f0efd9538c086a22033d27d0f06c3275208fed9
+    Latest digest: sha256:9634a8bcb5962f922dbb3941e60f667ca174252fa7506e73e3d034946d3abd62
     """
     return _harbor_base(
         package_name="blobfishai/factorybench-100",
@@ -2462,37 +2555,6 @@ def lcb_longswebench_32k(
 
 
 @task
-def lica_world_gdb(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""GraphicDesignBench (GDB): evaluating AI on graphic design tasks across layout, typography, infographics, template design, and animation.
-
-    Slug: lica-world/gdb
-    Latest digest: sha256:bd7a447e5db63f97de0a215d3cce01b87fe17fc7ea0a56cd9c29ad502b5b24fa
-    """
-    return _harbor_base(
-        package_name="lica-world/gdb",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def livecodebench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2538,7 +2600,7 @@ def luosuu_swe_kokkos_bench(
     r"""100 verified SWE-bench-style coding tasks from the Kokkos ecosystem
 
     Slug: luosuu/SWE-kokkos-bench
-    Latest digest: sha256:a6e1e95fad48ad9ddf49a6e7d4605f2ff5e38f2f6b5aa6bf8fa4288a2385bef2
+    Latest digest: sha256:2d2cf7e0ad502943456bc7ea738c297f1c4b1841aff2bc967a1d1c6ab6400d68
     """
     return _harbor_base(
         package_name="luosuu/SWE-kokkos-bench",

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -602,37 +602,6 @@ def algotune(
 
 
 @task
-def alibaba_aaig_alibaba_ctf(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""A dataset of 87 Capture-The-Flag tasks curated from the AlibabaCTF competition series (2023-2026) for evaluating agents on offensive security work.
-
-    Slug: alibaba-aaig/alibaba-ctf
-    Latest digest: sha256:9d50ae96f650f75d66a797a9a0ebfab8f5456edac8cc790d416b03356c032f16
-    """
-    return _harbor_base(
-        package_name="alibaba-aaig/alibaba-ctf",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def android_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1054,6 +1023,37 @@ def blobfishai_factorybench_100(
     """
     return _harbor_base(
         package_name="blobfishai/factorybench-100",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_hubbench(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub professional-domain cluster — 96 stateful multi-system employee-decision tasks over isolated SQLite worlds (HubScore, no LLM judge)
+
+    Slug: blobfishai/hubbench
+    Latest digest: sha256:ebd5ad39e289e7c75ab861da303d6a9b859abba556546490831acb85f4e1b041
+    """
+    return _harbor_base(
+        package_name="blobfishai/hubbench",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -2555,6 +2555,37 @@ def lcb_longswebench_32k(
 
 
 @task
+def lica_world_gdb(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Full GraphicDesignBench (GDB) benchmark converted to Harbor tasks.
+
+    Slug: lica-world/gdb
+    Latest digest: sha256:bd7a447e5db63f97de0a215d3cce01b87fe17fc7ea0a56cd9c29ad502b5b24fa
+    """
+    return _harbor_base(
+        package_name="lica-world/gdb",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def livecodebench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2972,10 +3003,41 @@ def orca_bench(
     r"""ORCA-bench: root-cause analysis of oncall incidents — agents investigate telemetry from an instrumented microservices system to diagnose each incident; public split of 755 tasks across 77 incidents (245 easy, 264 medium, 246 hard).
 
     Slug: orca-bench/orca-bench
-    Latest digest: sha256:1ef729757d4974ffe4e835d541c601f957975edf8c93ef02eec97e26d3069b93
+    Latest digest: sha256:3e53f8f8e64b58400549e793b280b59166a0dd64ccb656657c29c9f5f98b02c3
     """
     return _harbor_base(
         package_name="orca-bench/orca-bench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def orca_bench_orca_bench_verified(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""An agent benchmark for root cause analysis — verified split of 40 tasks across 40 incidents (10 easy, 15 medium, 15 hard). For the results on all 1,079 tasks, please see https://arxiv.org/abs/2607.28545.
+
+    Slug: orca-bench/orca-bench-verified
+    Latest digest: sha256:263a25d01329e4409bc03bfcd9e6d9771d189f6060a4b2db831b5e89783f7162
+    """
+    return _harbor_base(
+        package_name="orca-bench/orca-bench-verified",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
alibaba-aaig/alibaba-ctf
blobfishai/dealbench-100-suite
blobfishai/erpbench-100-suite
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks