### PR TITLE
fix: update Harbor registry tasks

### DIFF
--- a/docs/exclude.yml
+++ b/docs/exclude.yml
@@ -189,3 +189,26 @@
 # collision), title: ORCA-bench Verified, repo orca-bench/ORCA-bench,
 # arxiv 2607.28545, and a desc override trimming the dangling "please see."
 - orca-bench/orca-bench-verified
+# TEMPORARILY excluded (would otherwise be kept): six synthetic CRM workflow
+# tasks from the Blobfish AI org (source repo
+# blobfishai/arc-crm-agent-simulation, clean-room worlds inspired by the Arc
+# CRM dataset) — fails to load because inspect_ai's ComposeConfig rejects
+# pids_limit on both the `main` and `world` services (all six tasks use it).
+# Re-include once supported (fix proposed upstream) with overrides:
+# categories ~[Assistants, Professional], title: Blobfish Arc CRM-6, repo
+# above. Small 6-task set with "not a leaderboard" caveats in its README;
+# double-check it is still wanted when re-including.
+- blobfishai/arc-crm-6
+# Individual's (User, not org) 9-task "smoke suite from Terminal-Bench 2.1
+# for LibrAgent harness eval" (LibrAgent is the user's personal desktop-agent
+# project; no libragent benchmark repo exists). A curated subset of
+# terminal-bench/terminal-bench-2-1, which we list canonically — same
+# derivative-subset class as titouanlne/* and ryanmarten/*. It positions
+# itself as "disjoint from NovitaAI/tb21-file-recovery", a slice we already
+# exclude.
+- fritzprix/*
+# Individual's (User, not org) registry-plumbing test artifact: a 1-sample,
+# date-stamped "Synth Registry immutable dataset history acceptance" upload
+# whose single task is the standard harbor/hello-world task verbatim (which
+# we already exclude). Not a benchmark.
+- nlile/*

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -274,6 +274,9 @@ binary-audit/binary-audit:
   function_name: binary_audit
   title: BinaryAudit
 
+blobfishai/arc-crm-6:
+  categories: []
+
 blobfishai/dealbench-100-suite:
   categories:
   - Finance
@@ -314,6 +317,9 @@ blobfishai/hubbench:
   - Professional
   title: HubBench
   repo: https://github.com/blobfishai/hub-agent-simulation
+
+blobfishai/semikongbench-100:
+  categories: []
 
 cais/swebenchpro:
   categories:
@@ -440,6 +446,9 @@ featurebench/featurebench-modal:
   desc: FeatureBench's full task suite executed on Modal's cloud sandbox runner.
   function_name: featurebench_modal
   title: FeatureBench (Modal)
+
+fritzprix/libragent-diverse-9:
+  categories: []
 
 futurehouse/bixbench:
   categories:
@@ -727,6 +736,9 @@ maxbittker/runebench:
   - Behavior
   repo: https://github.com/MaxBittker/rs-sdk
 
+mercor/apex-agents-1-1:
+  categories: []
+
 meta/mlgym-bench:
   categories:
   - Coding
@@ -761,6 +773,9 @@ nl2repobench/nl2repobench:
   desc: Agent generates a complete, installable Python library from a single natural-language requirements document, starting from an empty workspace.
   function_name: nl2repobench
   title: NL2Repo-Bench
+
+nlile/registry-history-20260908:
+  categories: []
 
 nvats/codeskills-bench:
   categories:

--- a/docs/overrides.yml
+++ b/docs/overrides.yml
@@ -274,9 +274,6 @@ binary-audit/binary-audit:
   function_name: binary_audit
   title: BinaryAudit
 
-blobfishai/arc-crm-6:
-  categories: []
-
 blobfishai/dealbench-100-suite:
   categories:
   - Finance
@@ -319,7 +316,11 @@ blobfishai/hubbench:
   repo: https://github.com/blobfishai/hub-agent-simulation
 
 blobfishai/semikongbench-100:
-  categories: []
+  categories:
+  - Assistants
+  - Professional
+  title: SemiKongBench-100
+  repo: https://github.com/blobfishai/semiconductor-agent-simulation
 
 cais/swebenchpro:
   categories:
@@ -446,9 +447,6 @@ featurebench/featurebench-modal:
   desc: FeatureBench's full task suite executed on Modal's cloud sandbox runner.
   function_name: featurebench_modal
   title: FeatureBench (Modal)
-
-fritzprix/libragent-diverse-9:
-  categories: []
 
 futurehouse/bixbench:
   categories:
@@ -737,7 +735,12 @@ maxbittker/runebench:
   repo: https://github.com/MaxBittker/rs-sdk
 
 mercor/apex-agents-1-1:
-  categories: []
+  categories:
+  - Professional
+  - Assistants
+  title: APEX-Agents 1.1
+  repo: https://github.com/Mercor-Intelligence/apex_loop_truncated_tools_agent
+  arxiv: https://arxiv.org/abs/2601.14242
 
 meta/mlgym-bench:
   categories:
@@ -773,9 +776,6 @@ nl2repobench/nl2repobench:
   desc: Agent generates a complete, installable Python library from a single natural-language requirements document, starting from an empty workspace.
   function_name: nl2repobench
   title: NL2Repo-Bench
-
-nlile/registry-history-20260908:
-  categories: []
 
 nvats/codeskills-bench:
   categories:

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -273,6 +273,13 @@
   version: latest
   categories:
   - Cybersecurity
+- title: blobfishai/arc-crm-6
+  path: registry/blobfishai_arc_crm_6.html
+  desc: Six independently authored synthetic CRM workflows on one mocked CLI/web/REST/MCP world per episode. Partial Arc-inspired coverage, not source-row reproduction.
+  desc_trunc: Six independently authored synthetic CRM workflows on one mocked CLI/web/REST/MCP world per episode…
+  task_function: blobfishai_arc_crm_6
+  samples: 6
+  version: latest
 - title: blobfishai/dealbench-100-suite
   path: registry/blobfishai_dealbench_100_suite.html
   desc: 100 executable investment-banking workflows with deterministic DealScore grading.
@@ -325,14 +332,21 @@
   - Professional
 - title: blobfishai/hubbench
   path: registry/blobfishai_hubbench.html
-  desc: 'HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub professional-domain cluster — 96 stateful multi-system employee-decision tasks over isolated SQLite worlds (HubScore, no LLM judge).'
+  desc: 'HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub professional-domain cluster — 104 stateful multi-system employee-decision tasks over isolated SQLite worlds (HubScore, no LLM judge).'
   desc_trunc: 'HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub prof…'
   task_function: blobfishai_hubbench
-  samples: 96
+  samples: 104
   version: latest
   categories:
   - Assistants
   - Professional
+- title: blobfishai/semikongbench-100
+  path: registry/blobfishai_semikongbench_100.html
+  desc: 100 executable semiconductor exception workflows with deterministic SemiOpsScore grading.
+  desc_trunc: 100 executable semiconductor exception workflows with deterministic SemiOpsScore grading.
+  task_function: blobfishai_semikongbench_100
+  samples: 100
+  version: latest
 - title: cais/swebenchpro
   path: registry/cais_swebenchpro.html
   desc: SWE-bench Pro with anti-exploitation (git history isolation + GitHub network blocking). 731 tasks, Python/JS/TS/Go.
@@ -481,6 +495,13 @@
   version: latest
   categories:
   - Coding
+- title: fritzprix/libragent-diverse-9
+  path: registry/fritzprix_libragent_diverse_9.html
+  desc: 'Stratified 9-task smoke suite from Terminal-Bench 2.1 for LibrAgent harness eval. Difficulty mix: 2 easy / 4 medium / 3 hard across 7 categories (SE, debugging, sysadmin, security, data-science, scientific-computing, data-querying). Disjoint from NovitaAI/tb21-file-recovery. See README for sampling rationale and per-task notes.'
+  desc_trunc: 'Stratified 9-task smoke suite from Terminal-Bench 2.1 for LibrAgent harness eval. Difficulty mix: 2…'
+  task_function: fritzprix_libragent_diverse_9
+  samples: 9
+  version: latest
 - title: futurehouse/bixbench
   path: registry/futurehouse_bixbench.html
   desc: 'BixBench: real-world bioinformatics analysis capsules with open-answer questions evaluating LLM agents'' ability to author multi-step Jupyter notebooks for biological data analysis.'
@@ -535,8 +556,8 @@
   - Multimodal
 - title: gnucleus-ai/cad-bench
   path: registry/gnucleus_ai_cad_bench.html
-  desc: gNucleus AI CAD-generation benchmark — 100 parametric FreeCAD tasks.
-  desc_trunc: gNucleus AI CAD-generation benchmark — 100 parametric FreeCAD tasks.
+  desc: gNucleus AI CAD-generation benchmark -- 100 parametric FreeCAD tasks (Harbor schema 1.2; requires harbor >= 0.13.2).
+  desc_trunc: gNucleus AI CAD-generation benchmark -- 100 parametric FreeCAD tasks (Harbor schema 1.2; requires h…
   task_function: gnucleus_ai_cad_bench
   samples: 100
   version: latest
@@ -834,6 +855,13 @@
   categories:
   - Reasoning
   - Behavior
+- title: mercor/apex-agents-1-1
+  path: registry/mercor_apex_agents_1_1.html
+  desc: Long-horizon professional-services benchmark in investment banking, law, and management consulting, written by practicing analysts, consultants, and corporate lawyers. For evaluation only.
+  desc_trunc: Long-horizon professional-services benchmark in investment banking, law, and management consulting,…
+  task_function: mercor_apex_agents_1_1
+  samples: 240
+  version: latest
 - title: meta/mlgym-bench
   path: registry/meta_mlgym_bench.html
   desc: 'MLGym-Bench: Meta''s framework and benchmark for AI research agents covering CV, NLP, RL, and game-theory tasks requiring ideation, implementation, training, and analysis of ML experiments.'
@@ -873,6 +901,13 @@
   version: latest
   categories:
   - Coding
+- title: nlile/registry-history-20260908
+  path: registry/nlile_registry_history_20260908.html
+  desc: Synth Registry immutable dataset history acceptance. One public upstream task, exact pinned membership. Revision two changes the selected task version.
+  desc_trunc: Synth Registry immutable dataset history acceptance. One public upstream task, exact pinned members…
+  task_function: nlile_registry_history_20260908
+  samples: 1
+  version: latest
 - title: nvats/codeskills-bench
   path: registry/nvats_codeskills_bench.html
   desc: 'A small set of real-life programming tasks: bug fixes, merge-conflict resolution, dependency cleanup, API migration, and performance regressions across compact Python repositories.'
@@ -1044,10 +1079,10 @@
   - Coding
 - title: rounakbende10/rh-swe-bench
   path: registry/rounakbende10_rh_swe_bench.html
-  desc: Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos.
-  desc_trunc: Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos.
+  desc: Red Hat SWE-bench - 341 verified tasks from 25 RH ecosystem repos.
+  desc_trunc: Red Hat SWE-bench - 341 verified tasks from 25 RH ecosystem repos.
   task_function: rounakbende10_rh_swe_bench
-  samples: 357
+  samples: 341
   version: latest
   categories:
   - Coding

--- a/docs/registry-listing.yml
+++ b/docs/registry-listing.yml
@@ -273,13 +273,6 @@
   version: latest
   categories:
   - Cybersecurity
-- title: blobfishai/arc-crm-6
-  path: registry/blobfishai_arc_crm_6.html
-  desc: Six independently authored synthetic CRM workflows on one mocked CLI/web/REST/MCP world per episode. Partial Arc-inspired coverage, not source-row reproduction.
-  desc_trunc: Six independently authored synthetic CRM workflows on one mocked CLI/web/REST/MCP world per episode…
-  task_function: blobfishai_arc_crm_6
-  samples: 6
-  version: latest
 - title: blobfishai/dealbench-100-suite
   path: registry/blobfishai_dealbench_100_suite.html
   desc: 100 executable investment-banking workflows with deterministic DealScore grading.
@@ -347,6 +340,9 @@
   task_function: blobfishai_semikongbench_100
   samples: 100
   version: latest
+  categories:
+  - Assistants
+  - Professional
 - title: cais/swebenchpro
   path: registry/cais_swebenchpro.html
   desc: SWE-bench Pro with anti-exploitation (git history isolation + GitHub network blocking). 731 tasks, Python/JS/TS/Go.
@@ -495,13 +491,6 @@
   version: latest
   categories:
   - Coding
-- title: fritzprix/libragent-diverse-9
-  path: registry/fritzprix_libragent_diverse_9.html
-  desc: 'Stratified 9-task smoke suite from Terminal-Bench 2.1 for LibrAgent harness eval. Difficulty mix: 2 easy / 4 medium / 3 hard across 7 categories (SE, debugging, sysadmin, security, data-science, scientific-computing, data-querying). Disjoint from NovitaAI/tb21-file-recovery. See README for sampling rationale and per-task notes.'
-  desc_trunc: 'Stratified 9-task smoke suite from Terminal-Bench 2.1 for LibrAgent harness eval. Difficulty mix: 2…'
-  task_function: fritzprix_libragent_diverse_9
-  samples: 9
-  version: latest
 - title: futurehouse/bixbench
   path: registry/futurehouse_bixbench.html
   desc: 'BixBench: real-world bioinformatics analysis capsules with open-answer questions evaluating LLM agents'' ability to author multi-step Jupyter notebooks for biological data analysis.'
@@ -862,6 +851,9 @@
   task_function: mercor_apex_agents_1_1
   samples: 240
   version: latest
+  categories:
+  - Professional
+  - Assistants
 - title: meta/mlgym-bench
   path: registry/meta_mlgym_bench.html
   desc: 'MLGym-Bench: Meta''s framework and benchmark for AI research agents covering CV, NLP, RL, and game-theory tasks requiring ideation, implementation, training, and analysis of ML experiments.'
@@ -901,13 +893,6 @@
   version: latest
   categories:
   - Coding
-- title: nlile/registry-history-20260908
-  path: registry/nlile_registry_history_20260908.html
-  desc: Synth Registry immutable dataset history acceptance. One public upstream task, exact pinned membership. Revision two changes the selected task version.
-  desc_trunc: Synth Registry immutable dataset history acceptance. One public upstream task, exact pinned members…
-  task_function: nlile_registry_history_20260908
-  samples: 1
-  version: latest
 - title: nvats/codeskills-bench
   path: registry/nvats_codeskills_bench.html
   desc: 'A small set of real-life programming tasks: bug fixes, merge-conflict resolution, dependency cleanup, API migration, and performance regressions across compact Python repositories.'

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -881,6 +881,37 @@ def binary_audit(
 
 
 @task
+def blobfishai_arc_crm_6(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Six independently authored synthetic CRM workflows on one mocked CLI/web/REST/MCP world per episode. Partial Arc-inspired coverage, not source-row reproduction.
+
+    Slug: blobfishai/arc-crm-6
+    Latest digest: sha256:fc9ca3b80d6a1a3c3e5bd1b975c54f1f3ada21b49668cb5f25e2912d67b69dfa
+    """
+    return _harbor_base(
+        package_name="blobfishai/arc-crm-6",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def blobfishai_dealbench_100_suite(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1047,13 +1078,44 @@ def blobfishai_hubbench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub professional-domain cluster — 96 stateful multi-system employee-decision tasks over isolated SQLite worlds (HubScore, no LLM judge)
+    r"""HubBench: one oracle-proven, deterministically graded Blobfish benchmark family per Harbor Hub professional-domain cluster — 104 stateful multi-system employee-decision tasks over isolated SQLite worlds (HubScore, no LLM judge)
 
     Slug: blobfishai/hubbench
-    Latest digest: sha256:ebd5ad39e289e7c75ab861da303d6a9b859abba556546490831acb85f4e1b041
+    Latest digest: sha256:5856ea4f83229e77b238a2acc3714c4d5e45329aed6e564819832a76cb33d5c6
     """
     return _harbor_base(
         package_name="blobfishai/hubbench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def blobfishai_semikongbench_100(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""100 executable semiconductor exception workflows with deterministic SemiOpsScore grading
+
+    Slug: blobfishai/semikongbench-100
+    Latest digest: sha256:98ce5f040e311b2555d4eb7d3b4779a69f5ec5ea5d0a9aeae80b487588f2d6ff
+    """
+    return _harbor_base(
+        package_name="blobfishai/semikongbench-100",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -1563,6 +1625,37 @@ def featurebench_modal(
 
 
 @task
+def fritzprix_libragent_diverse_9(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Stratified 9-task smoke suite from Terminal-Bench 2.1 for LibrAgent harness eval. Difficulty mix: 2 easy / 4 medium / 3 hard across 7 categories (SE, debugging, sysadmin, security, data-science, scientific-computing, data-querying). Disjoint from NovitaAI/tb21-file-recovery. See README for sampling rationale and per-task notes.
+
+    Slug: fritzprix/libragent-diverse-9
+    Latest digest: sha256:1c6ca88bce2eb7fd95ebc9ba946c8168e03137c4b15e68f4e3402c21795460f7
+    """
+    return _harbor_base(
+        package_name="fritzprix/libragent-diverse-9",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def futurehouse_bixbench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1729,10 +1822,10 @@ def gnucleus_ai_cad_bench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""gNucleus AI CAD-generation benchmark — 100 parametric FreeCAD tasks
+    r"""gNucleus AI CAD-generation benchmark -- 100 parametric FreeCAD tasks (Harbor schema 1.2; requires harbor >= 0.13.2)
 
     Slug: gnucleus-ai/cad-bench
-    Latest digest: sha256:22be8aa80fdbf2d9844e73c9d91ee7e01082d70bcf706d347216d0b97bdf862e
+    Latest digest: sha256:ab2e040d0adcfd2779b4f1ad554890cd98b5aa19845e00162933ba165144fe56
     """
     return _harbor_base(
         package_name="gnucleus-ai/cad-bench",
@@ -2679,6 +2772,37 @@ def maxbittker_runebench(
 
 
 @task
+def mercor_apex_agents_1_1(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Long-horizon professional-services benchmark in investment banking, law, and management consulting, written by practicing analysts, consultants, and corporate lawyers. For evaluation only.
+
+    Slug: mercor/apex-agents-1-1
+    Latest digest: sha256:54b122068fbdd2119928e7c70a017733676571b3fb5a6270846b749a960c039e
+    """
+    return _harbor_base(
+        package_name="mercor/apex-agents-1-1",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
 def meta_mlgym_bench(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -2790,6 +2914,37 @@ def nl2repobench(
     """
     return _harbor_base(
         package_name="nl2repobench/nl2repobench",
+        package_ref=ref,
+        dataset_task_names=dataset_task_names,
+        dataset_exclude_task_names=dataset_exclude_task_names,
+        n_tasks=n_tasks,
+        overwrite_cache=overwrite_cache,
+        sandbox_env_name=sandbox_env_name,
+        override_cpus=override_cpus,
+        override_memory_mb=override_memory_mb,
+        override_gpus=override_gpus,
+    )
+
+
+@task
+def nlile_registry_history_20260908(
+    ref: str = "latest",
+    dataset_task_names: list[str] | None = None,
+    dataset_exclude_task_names: list[str] | None = None,
+    n_tasks: int | None = None,
+    overwrite_cache: bool = False,
+    sandbox_env_name: str = "docker",
+    override_cpus: int | None = None,
+    override_memory_mb: int | None = None,
+    override_gpus: int | None = None,
+) -> Task:
+    r"""Synth Registry immutable dataset history acceptance. One public upstream task, exact pinned membership. Revision two changes the selected task version.
+
+    Slug: nlile/registry-history-20260908
+    Latest digest: sha256:35bc3cc70cc751d77324d48a85b829aeccb482db68e59f78595b8eb535398c8e
+    """
+    return _harbor_base(
+        package_name="nlile/registry-history-20260908",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -3378,10 +3533,10 @@ def rounakbende10_rh_swe_bench(
     override_memory_mb: int | None = None,
     override_gpus: int | None = None,
 ) -> Task:
-    r"""Red Hat SWE-bench - 357 verified tasks from 25 RH ecosystem repos
+    r"""Red Hat SWE-bench - 341 verified tasks from 25 RH ecosystem repos
 
     Slug: rounakbende10/rh-swe-bench
-    Latest digest: sha256:c0a3c223a96b0536e69a4b382c731f425285538f9bbc10972a203613aa4ffad2
+    Latest digest: sha256:96005bdeb80c90e6a487df8cb893dc2856b2bec88d122a14580abcc58481ef75
     """
     return _harbor_base(
         package_name="rounakbende10/rh-swe-bench",

--- a/src/inspect_harbor/_tasks.py
+++ b/src/inspect_harbor/_tasks.py
@@ -881,37 +881,6 @@ def binary_audit(
 
 
 @task
-def blobfishai_arc_crm_6(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Six independently authored synthetic CRM workflows on one mocked CLI/web/REST/MCP world per episode. Partial Arc-inspired coverage, not source-row reproduction.
-
-    Slug: blobfishai/arc-crm-6
-    Latest digest: sha256:fc9ca3b80d6a1a3c3e5bd1b975c54f1f3ada21b49668cb5f25e2912d67b69dfa
-    """
-    return _harbor_base(
-        package_name="blobfishai/arc-crm-6",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
 def blobfishai_dealbench_100_suite(
     ref: str = "latest",
     dataset_task_names: list[str] | None = None,
@@ -1612,37 +1581,6 @@ def featurebench_modal(
     """
     return _harbor_base(
         package_name="featurebench/featurebench-modal",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def fritzprix_libragent_diverse_9(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Stratified 9-task smoke suite from Terminal-Bench 2.1 for LibrAgent harness eval. Difficulty mix: 2 easy / 4 medium / 3 hard across 7 categories (SE, debugging, sysadmin, security, data-science, scientific-computing, data-querying). Disjoint from NovitaAI/tb21-file-recovery. See README for sampling rationale and per-task notes.
-
-    Slug: fritzprix/libragent-diverse-9
-    Latest digest: sha256:1c6ca88bce2eb7fd95ebc9ba946c8168e03137c4b15e68f4e3402c21795460f7
-    """
-    return _harbor_base(
-        package_name="fritzprix/libragent-diverse-9",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,
@@ -2914,37 +2852,6 @@ def nl2repobench(
     """
     return _harbor_base(
         package_name="nl2repobench/nl2repobench",
-        package_ref=ref,
-        dataset_task_names=dataset_task_names,
-        dataset_exclude_task_names=dataset_exclude_task_names,
-        n_tasks=n_tasks,
-        overwrite_cache=overwrite_cache,
-        sandbox_env_name=sandbox_env_name,
-        override_cpus=override_cpus,
-        override_memory_mb=override_memory_mb,
-        override_gpus=override_gpus,
-    )
-
-
-@task
-def nlile_registry_history_20260908(
-    ref: str = "latest",
-    dataset_task_names: list[str] | None = None,
-    dataset_exclude_task_names: list[str] | None = None,
-    n_tasks: int | None = None,
-    overwrite_cache: bool = False,
-    sandbox_env_name: str = "docker",
-    override_cpus: int | None = None,
-    override_memory_mb: int | None = None,
-    override_gpus: int | None = None,
-) -> Task:
-    r"""Synth Registry immutable dataset history acceptance. One public upstream task, exact pinned membership. Revision two changes the selected task version.
-
-    Slug: nlile/registry-history-20260908
-    Latest digest: sha256:35bc3cc70cc751d77324d48a85b829aeccb482db68e59f78595b8eb535398c8e
-    """
-    return _harbor_base(
-        package_name="nlile/registry-history-20260908",
         package_ref=ref,
         dataset_task_names=dataset_task_names,
         dataset_exclude_task_names=dataset_exclude_task_names,


### PR DESCRIPTION
## 🤖 Automated Update

This PR updates the Harbor registry tasks to reflect the latest datasets available in the [Harbor registry](https://registry.harborframework.com/).

### Changes
- Updated `src/inspect_harbor/_tasks.py` with latest registry datasets
- Updated `docs/registry-listing.yml` with current dataset information

### ⚠️ Action required: fill in categories for new datasets

The following datasets were added to `docs/overrides.yml` with empty `categories`. Fill in one or more categories (see vocabulary in the file's header) before merging, or the `validate-overrides` CI check will block this PR:

```
blobfishai/arc-crm-6
blobfishai/semikongbench-100
fritzprix/libragent-diverse-9
mercor/apex-agents-1-1
nlile/registry-history-20260908
```

### 📤 After merging: publish docs

Docs are not auto-published — the live site at https://meridianlabs-ai.github.io/inspect_harbor stays frozen until someone pushes a new `gh-pages` build. Once this PR is merged, pull `main` locally and run:

```bash
cd docs
uv run quarto publish gh-pages
```

This re-renders the registry listing and per-benchmark pages against the latest Harbor registry and pushes them to the `gh-pages` branch, which GitHub Pages serves.

### Details
- **Generated by**: `scripts/generate_tasks.py`
- **Triggered by**: schedule
- **Workflow**: Update Harbor Registry Tasks