### PR TITLE
docs: document OpenAI 3 dependency workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,16 @@
 [Harbor](https://harborframework.com/) is a framework for building, evaluating, and optimizing AI agents in containerized environments. Inspect Harbor provides an interface to run Harbor tasks using [Inspect AI](https://inspect.aisi.org.uk/).
 
 ```bash
-pip install inspect-harbor
+pip install "inspect-harbor>=0.5"
 ```
+
+> [!WARNING]
+> Harbor's LiteLLM dependency currently requires `openai<3`, while Inspect's
+> OpenAI provider requires `openai>=3.1`. The version floor above prevents the
+> resolver from silently installing an obsolete `inspect-harbor` whose task
+> names do not match the current documentation. If you use OpenAI models, see
+> the temporary [OpenAI 3 compatibility
+> instructions](https://meridianlabs-ai.github.io/inspect_harbor/#openai-3-compatibility).
 
 Then in Python:
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -10,14 +10,48 @@ llms-description: Overview, installation, prerequisites, and quick start for Ins
 Install from PyPI:
 
 ```bash
-pip install inspect-harbor
+pip install "inspect-harbor>=0.5"
 ```
 
 Or with uv:
 
 ```bash
-uv add inspect-harbor
+uv add "inspect-harbor>=0.5"
 ```
+
+The `>=0.5` floor is important: version 0.5 introduced the organization-qualified
+Harbor registry used by these docs. Without the floor, a dependency resolver may
+silently select an older release whose task names do not match the examples below.
+
+### OpenAI 3 compatibility
+
+::: {.callout-warning}
+Harbor depends on LiteLLM, which currently declares `openai<3`, while Inspect's
+OpenAI provider requires `openai>=3.1`. The two declared dependency ranges cannot
+be resolved together. This is tracked upstream in [LiteLLM
+#37907](https://github.com/BerriAI/litellm/issues/37907).
+:::
+
+If your uv project uses OpenAI models, add a temporary override for LiteLLM's
+upper bound to the project's existing `pyproject.toml`:
+
+```toml
+[tool.uv]
+override-dependencies = ["openai>=3.1.0"]
+```
+
+Then add both direct dependencies:
+
+```bash
+uv add "inspect-harbor>=0.5" "openai>=3.1.0"
+```
+
+This override is limited to the Inspect Harbor execution path, where Inspect—not
+LiteLLM—runs the model. Do not use the resulting environment for Harbor's own
+LiteLLM-backed model execution; LiteLLM does not yet declare OpenAI 3 support.
+If you do not need OpenAI models, no override is necessary. pip does not offer
+an equivalent persistent override; use a uv-managed environment for this
+temporary OpenAI configuration.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Require `inspect-harbor>=0.5` in installation examples so dependency resolution cannot silently select the pre-organization registry release.
- Explain the conflict between the OpenAI versions required by Inspect and allowed by LiteLLM.
- Document a scoped uv override for OpenAI model users and warn against using that environment for Harbor LiteLLM execution.

## Verification

- Resolved a fresh project with `inspect-harbor>=0.5`, `openai>=3.1.0`, and the documented uv override.
- Rendered `docs/index.qmd` successfully.
- Ran pre-commit against the changed documentation files.

Upstream LiteLLM issue: https://github.com/BerriAI/litellm/issues/37907