### PR TITLE
ci: resync the Claude dev-agent stub with agents#93 (@auto cost filter)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,16 +1,32 @@
-# Dev agent (@claude) — thin stub over the shared Meridian workflow in
-# meridianlabs-ai/agents. Mention @claude in an issue or PR comment (or add the
-# `claude` label to an issue) and Claude edits/pushes on a branch.
+# Copy this file to .github/workflows/claude.yml in any Meridian repo
+# (or run scripts/enable-claude.sh <org/repo> to open a PR that adds it).
 #
-# The second job (@auto) reuses the SAME dev workflow but is the autonomous
-# kickoff: an `@auto` mention or `auto` label makes the agent open/adopt a PR,
-# carry the `auto` label onto it, and hand off to the loop in claude-auto.yml.
+# Requires only that the Claude GitHub App is installed on the repo
+# (org-level install covers this). Auth uses Workload Identity Federation —
+# no secrets needed, but `id-token: write` below is required for the OIDC
+# exchange.
 
 name: Claude
 
+# Trigger-resolution caveat: GitHub runs issue_comment / issues workflows from
+# the DEFAULT branch, but pull_request_review_comment / pull_request_review
+# (the pull_request family) from the PR's OWN branches. So the latter two only
+# fire where this file exists on the PR's base/head branch. On a pristine-base
+# mirror like the inspect_ai fork — where the Claude workflows live only on the
+# default branch and PRs target an upstream-mirror base that lacks them — those
+# two never fire; only top-level @claude comments (issue_comment) and the
+# `claude` label (issues) work. Drop the two review triggers in that setup so
+# the surface matches reality (the fork's deployed stub does).
+#
+# `issue_comment: edited` is included so that ADDING @claude/@auto to an
+# existing comment (a common way people invoke the agent after the fact) fires
+# the workflow — GitHub only delivers the edited action when it's subscribed
+# here. The job `if:` below guards it to edits that newly introduce the phrase
+# (via github.event.changes.body.from), so re-editing a comment that already
+# mentioned the agent does NOT re-trigger it.
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
   pull_request_review_comment:
     types: [created]
   pull_request_review:
@@ -20,18 +36,73 @@ on:
 
 jobs:
   claude:
+    # Cheap gate to avoid spending runner minutes on unrelated events; the
+    # action does its own authoritative trigger check. Two phrases summon the
+    # one-shot dev agent: @claude and @i-am-marvin (the machine account — a real
+    # user, so the mention resolves to it and pings nothing else). They do the
+    # same thing; the action's trigger_phrase is single-valued, so
+    # `with.trigger_phrase` below resolves which phrase the *event's own text*
+    # contains (comment body for a comment, review body for a review, issue
+    # body/title for an issue — the same source the action checks) and this gate
+    # fires if that text has either phrase.
+    #
+    # Machine-account guard: github.actor != 'i-am-marvin' over the whole gate,
+    # so a comment/review/issue authored by the machine account can't self-
+    # trigger the dev agent and loop (its own output — and the fork guidance —
+    # can contain @claude/@i-am-marvin). Hoisted rather than per-source: the
+    # sources are OR'd, so guarding only the comment branch is bypassable by a
+    # phrase left in the enclosing issue body/title.
+    #
+    # Sources are scoped to the event that carries them (github.event.action /
+    # event_name), so a comment event is judged by the comment alone — a stale
+    # @claude in the enclosing issue can't fire a runner-spin for an unrelated
+    # comment, nor mask an alias typed in the comment.
+    #
+    # On an edited comment (the only `edited` action we subscribe to), fire only
+    # when the edit newly introduced a phrase — comparing against the pre-edit
+    # body — so re-editing a comment that already mentioned one does not
+    # re-trigger. Known limitation: contains() is a substring test, looser than
+    # the action's word-boundary trigger; a pre-edit body holding a phrase only
+    # as a NON-triggering substring (in backticks, or a token like foo@claude)
+    # blocks the edit path. Acceptable for a cheap gate (no regex in workflow
+    # expressions); the action remains the authoritative check on what fires.
     if: |
-      contains(github.event.comment.body, '@claude') ||
-      contains(github.event.review.body, '@claude') ||
-      contains(github.event.issue.body, '@claude') ||
-      contains(github.event.issue.title, '@claude') ||
-      github.event.label.name == 'claude'
+      github.actor != 'i-am-marvin' && !endsWith(github.actor, '[bot]') && (
+        ( github.event.action == 'edited'
+          && ( contains(github.event.comment.body, '@claude')
+            || contains(github.event.comment.body, '@i-am-marvin') )
+          && !( contains(github.event.changes.body.from, '@claude')
+            || contains(github.event.changes.body.from, '@i-am-marvin') ) ) ||
+        ( github.event.action == 'created' && (
+            contains(github.event.comment.body, '@claude') ||
+            contains(github.event.comment.body, '@i-am-marvin')
+        ) ) ||
+        ( github.event.action == 'submitted' && (
+            contains(github.event.review.body, '@claude') ||
+            contains(github.event.review.body, '@i-am-marvin')
+        ) ) ||
+        ( github.event_name == 'issues' && (
+            contains(github.event.issue.body, '@claude') ||
+            contains(github.event.issue.body, '@i-am-marvin') ||
+            contains(github.event.issue.title, '@claude') ||
+            contains(github.event.issue.title, '@i-am-marvin') ||
+            github.event.label.name == 'claude'
+        ) )
+      )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
-    # MARVIN_TOKEN (machine-account PAT, org secret) so agent-opened PRs trigger
-    # CI and @review. Passed explicitly, not via `secrets: inherit`. Absent ->
-    # empty: the agent still runs, just with issue-triggered PR creation degraded.
+    # Pass the machine-account PAT (MARVIN_TOKEN, an org secret) through to the
+    # reusable workflow so agent-opened PRs trigger CI and @review. Passed
+    # explicitly — NOT via `secrets: inherit` — so this repo's other secrets
+    # aren't exposed to an external workflow pinned to a mutable @main ref
+    # (least privilege; the reusable workflow consumes only this one secret).
+    # An absent MARVIN_TOKEN resolves to empty: the agent still runs, just with
+    # issue-triggered PR creation degraded (see the reusable workflow's
+    # secrets.MARVIN_TOKEN and design/auto-agent.md).
     secrets:
       MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+      # codex engine (design/codex-engine.md in the agents repo):
+      # consumed only on items labeled engine:codex; optional.
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     permissions:
       contents: write
       pull-requests: write
@@ -39,6 +110,29 @@ jobs:
       id-token: write
       actions: read
     with:
+      # trigger_phrase is single-valued, so resolve it from the SAME source the
+      # action will check for this event (comment > review > issue), not from a
+      # union of all sources — otherwise a stale @claude in an enclosing issue
+      # would mask an @i-am-marvin typed in a comment, resolving @claude and
+      # then no-op'ing (the action only checks the comment body on a comment
+      # event). Within a source, default @claude and only switch to
+      # @i-am-marvin when that's what's present; the trailing @claude covers the
+      # `claude` label event and is a harmless fallback.
+      # Caveat: this pick is substring-based (workflow expressions have no
+      # regex), so it also SELECTS which phrase the action then re-checks with
+      # word boundaries. In the contrived case where the other phrase appears
+      # only as a NON-triggering substring (backticked, or glued into a token
+      # like foo@i-am-marvin) a genuine trigger can be mis-resolved and no-op,
+      # not merely cost gate minutes. Accepted: the collision needs someone to,
+      # in one comment, write one phrase for real and the other as a bare
+      # substring — and both phrases route to the same dev agent anyway.
+      trigger_phrase: >-
+        ${{
+        github.event.comment && (contains(github.event.comment.body, '@i-am-marvin') && '@i-am-marvin' || '@claude') ||
+        github.event.review && (contains(github.event.review.body, '@i-am-marvin') && '@i-am-marvin' || '@claude') ||
+        (contains(github.event.issue.body, '@i-am-marvin') || contains(github.event.issue.title, '@i-am-marvin')) && '@i-am-marvin' ||
+        '@claude'
+        }}
       # Reusable default allow-list PLUS the research tools the triage skill
       # needs: WebSearch/WebFetch (benchmark lookups) and curl (Hugging Face /
       # GitHub API).
@@ -55,28 +149,73 @@ jobs:
         "Bash(git remote:*)",
         "Bash(git add:*)","Bash(git commit:*)","Bash(git config:*)"]}}
 
-  # @auto kickoff — same reusable dev workflow, distinct trigger. An `@auto`
-  # mention or `auto` label drives an issue/PR autonomously: the agent opens (or
-  # adopts) a PR, propagates the `auto` label so the loop in claude-auto.yml
-  # engages, and runs to a human handoff. trigger_phrase/label_trigger are
-  # single-valued, so `auto` needs its own invocation. Needs MARVIN_TOKEN — the
-  # PR must be authored by the machine account to trigger CI and @review.
+  # @auto kickoff (distinct from the one-shot `claude` above). An `auto` label or
+  # `@auto` mention drives the issue autonomously: the dev agent opens a PR, the
+  # PR inherits the `auto` label (so the loop in claude-auto.yml engages), and it
+  # runs to a human handoff. Same reusable dev workflow, different trigger — the
+  # action's trigger_phrase/label_trigger are single-valued, so `auto` needs its
+  # own invocation. Needs MARVIN_TOKEN (the PR must trigger CI/@review).
   claude-auto:
+    # See the `claude` job's `if:` — same edited-comment guard, so adding @auto
+    # to an existing comment kicks off the autonomous loop but re-editing a
+    # comment that already mentioned @auto does not re-fire it (which could
+    # otherwise open a duplicate PR). Same machine-account guard too: @auto is
+    # the loop-prone trigger, so keep the machine account from kicking it off
+    # (nothing in the designed loop relies on marvin posting @auto).
+    # Machine-account EXCEPTION — the auto-LABEL path: automation (e.g. a
+    # triage pipeline) may add the `auto` label as the machine account, and a
+    # label event's actor is whoever added it. The hoisted marvin guard ate
+    # that trigger (observed: inspect_ai#236). Labeling is safe to exempt:
+    # the gate reads the label NAME (no quoted-token hazard), labeling needs
+    # triage access, and the reusable workflow's trigger check verifies the
+    # labeler has write access before running. Comment/body paths keep the
+    # full guard.
+    # author_association filter (OWNER/MEMBER/COLLABORATOR) on the text
+    # paths: a COST filter, not the gate. On a public repo anyone can comment
+    # `@auto` on a PR; without this every such comment spun a runner. It is
+    # not authoritative — CONTRIBUTOR is anyone with a merged commit, and
+    # whether org members show as MEMBER depends on org settings — so the
+    # reusable workflow's trigger check (a fail-closed permission lookup on
+    # the actor, before any write) remains the authority. A collaborator
+    # whose association is reported looser than expected is dropped here
+    # silently; the trig check would refuse them anyway. The issue-body
+    # branch is scoped to `issues` events like the `claude` job's: an
+    # issue_comment payload also carries issue.body/author_association, so
+    # without the scope a member-authored issue mentioning @auto would let
+    # every comment from anyone spin a runner (refused by trig, but paid for).
     if: |
-      contains(github.event.comment.body, '@auto') ||
-      contains(github.event.review.body, '@auto') ||
-      contains(github.event.issue.body, '@auto') ||
-      contains(github.event.issue.title, '@auto') ||
-      github.event.label.name == 'auto'
+      ( github.event_name == 'issues' && github.event.action == 'labeled'
+        && github.event.label.name == 'auto'
+        && !endsWith(github.actor, '[bot]') ) ||
+      ( github.actor != 'i-am-marvin' && !endsWith(github.actor, '[bot]') && (
+        ( github.event.action == 'edited'
+          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+          && contains(github.event.comment.body, '@auto')
+          && !contains(github.event.changes.body.from, '@auto') ) ||
+        ( github.event.action != 'edited' && (
+            ( contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+              && contains(github.event.comment.body, '@auto') ) ||
+            ( contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+              && contains(github.event.review.body, '@auto') ) ||
+            ( github.event_name == 'issues'
+              && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+              && ( contains(github.event.issue.body, '@auto')
+                || contains(github.event.issue.title, '@auto') ) ) ||
+            github.event.label.name == 'auto'
+        ) )
+      ) )
     uses: meridianlabs-ai/agents/.github/workflows/claude.yml@main
+    secrets:
+      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
+      # codex engine (design/codex-engine.md in the agents repo):
+      # consumed only on items labeled engine:codex; optional.
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     permissions:
       contents: write
       pull-requests: write
       issues: write
       id-token: write
       actions: read
-    secrets:
-      MARVIN_TOKEN: ${{ secrets.MARVIN_TOKEN }}
     with:
       trigger_phrase: "@auto"
       label_trigger: "auto"


### PR DESCRIPTION
Stub sync for [meridianlabs-ai/agents#93](https://github.com/meridianlabs-ai/agents/pull/93), which changed `examples/claude-stub.yml`: the `claude-auto` job's text paths (`@auto` in a comment / review / issue) now carry an `author_association` filter (OWNER/MEMBER/COLLABORATOR) so a stranger's `@auto` comment on a public repo no longer spins a runner, and the issue-body branch is scoped to `issues` events. It is a **cost filter, not the gate** — the reusable workflow's fail-closed permission lookup on the actor (also from agents#93, live at `@main`) remains the authority; the in-file comment spells this out.

**This repo:** Refreshes the whole file from agents/examples/claude-stub.yml (it predated the marvin/bot guards, the edited-comment path and the @i-am-marvin alias), keeping this repo's one deliberate deviation: the triage skill's allow-list (`settings`) on both jobs. Also passes the optional OPENAI_API_KEY secret through like the example.

No behavior change for members/collaborators. Workflow-editing PR, so auto-review-on-open is skipped; `@review` requested by comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)